### PR TITLE
[2주차 - Step 2] 엔터티 초기화 (EntityLoader) PR 입니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ public class EntityPersister {
 - [x] RowMapper 클래스는 변환할 엔터티의 정보를 미리 가지고 있다가 객체를 받아 처리한다.
 
 - 요구사항 2 - EntityManager 의 책임 줄여주기
-- [ ] 기존 SimpleEntityManager 가 하던 find 로직을 EntityLoader 에게 위임한다.
+- [x] 기존 SimpleEntityManager 가 하던 find 로직을 EntityLoader 에게 위임한다.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ public class EntityPersister {
 `EntityLoader 는 엔터티를 데이터베이스에서 로드하고 로드된 엔터티 상태를 영속성 컨텍스트 내에서 추적 및 관리`
 
 - 요구사항 1 - RowMapper 리팩터링
-- [ ] RowMapper 를 클래스로 분리해서 책임을 맡긴다.
-- [ ] RowMapper 클래스는 변환할 엔터티의 정보를 미리 가지고 있다가 객체를 받아 처리한다.
+- [x] RowMapper 를 클래스로 분리해서 책임을 맡긴다.
+- [x] RowMapper 클래스는 변환할 엔터티의 정보를 미리 가지고 있다가 객체를 받아 처리한다.
 
 - 요구사항 2 - EntityManager 의 책임 줄여주기

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@
 public class EntityPersister {
 - 구현 해보기
 
-public boolean update(parameters는 자유롭게)
+    public boolean update(parameters는 자유롭게)
 
-public void insert(parameters는 자유롭게)
+    public void insert(parameters는 자유롭게)
 
-public void delete(parameters는 자유롭게)
+    public void delete(parameters는 자유롭게)
 ...
 }
 ```
@@ -31,3 +31,13 @@ public void delete(parameters는 자유롭게)
 `EntityManager 의 구현체에서 쿼리 생성 및 데이터 매핑 에 대한 책임을 EntityPersister 로 옮겨주자`
 
 - [x] 기존 SimpleEntityManager 가 하던 find, persist, remove 로직을 EntityPersister 에게 위임한다.
+
+
+### 2단계 - 엔터티 초기화 (EntityLoader)
+`EntityLoader 는 엔터티를 데이터베이스에서 로드하고 로드된 엔터티 상태를 영속성 컨텍스트 내에서 추적 및 관리`
+
+- 요구사항 1 - RowMapper 리팩터링
+- [ ] RowMapper 를 클래스로 분리해서 책임을 맡긴다.
+- [ ] RowMapper 클래스는 변환할 엔터티의 정보를 미리 가지고 있다가 객체를 받아 처리한다.
+
+- 요구사항 2 - EntityManager 의 책임 줄여주기

--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ public class EntityPersister {
 - [x] RowMapper 클래스는 변환할 엔터티의 정보를 미리 가지고 있다가 객체를 받아 처리한다.
 
 - 요구사항 2 - EntityManager 의 책임 줄여주기
+- [ ] 기존 SimpleEntityManager 가 하던 find 로직을 EntityLoader 에게 위임한다.

--- a/src/main/java/persistence/core/EntityColumns.java
+++ b/src/main/java/persistence/core/EntityColumns.java
@@ -17,6 +17,9 @@ public class EntityColumns implements Iterable<EntityColumn> {
     public EntityColumns(final Class<?> clazz) {
         this.columns = generateColumns(clazz);
     }
+    public EntityColumns(final List<EntityColumn> entityColumns) {
+        this.columns = entityColumns;
+    }
 
     private List<EntityColumn> generateColumns(final Class<?> clazz) {
         this.validate(clazz);
@@ -55,5 +58,17 @@ public class EntityColumns implements Iterable<EntityColumn> {
                 .filter(EntityColumn::isId)
                 .findFirst()
                 .orElseThrow(() -> new ColumnNotExistException("Id 컬럼이 존재하지 않습니다."));
+    }
+
+    public List<String> getNames() {
+        return this.columns.stream()
+                .map(EntityColumn::getName)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    public List<String> getFieldNames() {
+        return this.columns.stream()
+                .map(EntityColumn::getFieldName)
+                .collect(Collectors.toUnmodifiableList());
     }
 }

--- a/src/main/java/persistence/core/EntityMetadata.java
+++ b/src/main/java/persistence/core/EntityMetadata.java
@@ -81,4 +81,14 @@ public class EntityMetadata<T> {
                 .collect(Collectors.toUnmodifiableList());
     }
 
+    public EntityColumn getIdColumn() {
+        return this.idColumn;
+    }
+
+    public EntityColumns getInsertableColumn() {
+        return new EntityColumns(
+                this.columns.stream()
+                        .filter(EntityColumn::isInsertable)
+                        .collect(Collectors.toUnmodifiableList()));
+    }
 }

--- a/src/main/java/persistence/core/EntityMetadataProvider.java
+++ b/src/main/java/persistence/core/EntityMetadataProvider.java
@@ -15,8 +15,9 @@ public class EntityMetadataProvider {
         return InstanceHolder.INSTANCE;
     }
 
-    public EntityMetadata<?> getEntityMetadata(final Class<?> clazz) {
-        return cache.computeIfAbsent(clazz, EntityMetadata::new);
+    @SuppressWarnings("unchecked")
+    public <T> EntityMetadata<T> getEntityMetadata(final Class<T> clazz) {
+        return (EntityMetadata<T>) cache.computeIfAbsent(clazz, EntityMetadata::new);
     }
 
     private static class InstanceHolder {

--- a/src/main/java/persistence/core/PersistenceEnvironment.java
+++ b/src/main/java/persistence/core/PersistenceEnvironment.java
@@ -2,8 +2,6 @@ package persistence.core;
 
 import database.DatabaseServer;
 import persistence.dialect.Dialect;
-import persistence.entity.EntityLoaderProvider;
-import persistence.entity.EntityPersisterProvider;
 import persistence.exception.PersistenceException;
 import persistence.sql.dml.DmlGenerator;
 
@@ -14,15 +12,11 @@ public class PersistenceEnvironment {
     private final DatabaseServer server;
     private final Dialect dialect;
     private final DmlGenerator dmlGenerator;
-    private final EntityPersisterProvider entityPersisterProvider;
-    private final EntityLoaderProvider entityLoaderProvider;
 
     public PersistenceEnvironment(final DatabaseServer server, final Dialect dialect) {
         this.server = server;
         this.dialect = dialect;
         this.dmlGenerator = new DmlGenerator(dialect);
-        this.entityPersisterProvider = new EntityPersisterProvider(this);
-        this.entityLoaderProvider = new EntityLoaderProvider(this);
     }
 
     public Dialect getDialect() {
@@ -41,11 +35,4 @@ public class PersistenceEnvironment {
         return this.dmlGenerator;
     }
 
-    public EntityPersisterProvider getEntityPersisterProvider() {
-        return this.entityPersisterProvider;
-    }
-
-    public EntityLoaderProvider getEntityLoaderProvider() {
-        return this.entityLoaderProvider;
-    }
 }

--- a/src/main/java/persistence/core/PersistenceEnvironment.java
+++ b/src/main/java/persistence/core/PersistenceEnvironment.java
@@ -22,7 +22,7 @@ public class PersistenceEnvironment {
         this.dialect = dialect;
         this.dmlGenerator = new DmlGenerator(dialect);
         this.entityPersisterProvider = new EntityPersisterProvider(this);
-        this.entityLoaderProvider = new EntityLoaderProvider(this, this.entityPersisterProvider);
+        this.entityLoaderProvider = new EntityLoaderProvider(this);
     }
 
     public Dialect getDialect() {

--- a/src/main/java/persistence/core/PersistenceEnvironment.java
+++ b/src/main/java/persistence/core/PersistenceEnvironment.java
@@ -2,6 +2,8 @@ package persistence.core;
 
 import database.DatabaseServer;
 import persistence.dialect.Dialect;
+import persistence.entity.EntityLoaderProvider;
+import persistence.entity.EntityPersisterProvider;
 import persistence.exception.PersistenceException;
 import persistence.sql.dml.DmlGenerator;
 
@@ -12,11 +14,15 @@ public class PersistenceEnvironment {
     private final DatabaseServer server;
     private final Dialect dialect;
     private final DmlGenerator dmlGenerator;
+    private final EntityPersisterProvider entityPersisterProvider;
+    private final EntityLoaderProvider entityLoaderProvider;
 
     public PersistenceEnvironment(final DatabaseServer server, final Dialect dialect) {
         this.server = server;
         this.dialect = dialect;
         this.dmlGenerator = new DmlGenerator(dialect);
+        this.entityPersisterProvider = new EntityPersisterProvider(this);
+        this.entityLoaderProvider = new EntityLoaderProvider(this, this.entityPersisterProvider);
     }
 
     public Dialect getDialect() {
@@ -33,5 +39,13 @@ public class PersistenceEnvironment {
 
     public DmlGenerator getDmlGenerator() {
         return this.dmlGenerator;
+    }
+
+    public EntityPersisterProvider getEntityPersisterProvider() {
+        return this.entityPersisterProvider;
+    }
+
+    public EntityLoaderProvider getEntityLoaderProvider() {
+        return this.entityLoaderProvider;
     }
 }

--- a/src/main/java/persistence/entity/EntityLoader.java
+++ b/src/main/java/persistence/entity/EntityLoader.java
@@ -1,0 +1,28 @@
+package persistence.entity;
+
+import jdbc.JdbcTemplate;
+import persistence.sql.dml.DmlGenerator;
+
+public class EntityLoader<T> {
+
+    private final EntityPersister entityPersister;
+    private final JdbcTemplate jdbcTemplate;
+    private final DmlGenerator dmlGenerator;
+    private final EntityRowMapper<T> entityRowMapper;
+
+    public EntityLoader(final Class<T> clazz, final EntityPersister entityPersister, final JdbcTemplate jdbcTemplate, final DmlGenerator dmlGenerator) {
+        this.entityPersister = entityPersister;
+        this.jdbcTemplate = jdbcTemplate;
+        this.dmlGenerator = dmlGenerator;
+        this.entityRowMapper = new EntityRowMapper<>(clazz, entityPersister);
+    }
+
+    public T loadById(final Object id) {
+        final String query = renderSelect(id);
+        return jdbcTemplate.queryForObject(query, entityRowMapper::mapRow);
+    }
+
+    public String renderSelect(final Object id) {
+        return dmlGenerator.findById(entityPersister.getTableName(), entityPersister.getColumnNames(), entityPersister.getIdColumnName(), id);
+    }
+}

--- a/src/main/java/persistence/entity/EntityLoader.java
+++ b/src/main/java/persistence/entity/EntityLoader.java
@@ -1,35 +1,24 @@
 package persistence.entity;
 
 import jdbc.JdbcTemplate;
-import persistence.core.PersistenceEnvironment;
-import persistence.exception.PersistenceException;
 import persistence.sql.dml.DmlGenerator;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-
 public class EntityLoader<T> {
-    private final PersistenceEnvironment persistenceEnvironment;
-    private final EntityPersister entityPersister;
     private final DmlGenerator dmlGenerator;
+    private final JdbcTemplate jdbcTemplate;
+    private final EntityPersister entityPersister;
     private final EntityRowMapper<T> entityRowMapper;
 
-    public EntityLoader(final Class<T> clazz, final PersistenceEnvironment persistenceEnvironment, final EntityPersister entityPersister) {
-        this.persistenceEnvironment = persistenceEnvironment;
+    public EntityLoader(final Class<T> clazz, final DmlGenerator dmlGenerator, final JdbcTemplate jdbcTemplate, final EntityPersister entityPersister) {
         this.entityPersister = entityPersister;
-        this.dmlGenerator = persistenceEnvironment.getDmlGenerator();
+        this.dmlGenerator = dmlGenerator;
+        this.jdbcTemplate = jdbcTemplate;
         this.entityRowMapper = new EntityRowMapper<>(clazz, entityPersister);
     }
 
     public T loadById(final Object id) {
         final String query = renderSelect(id);
-        try (final Connection connection = persistenceEnvironment.getConnection()) {
-            final JdbcTemplate jdbcTemplate = new JdbcTemplate(connection);
-            return jdbcTemplate.queryForObject(query, entityRowMapper::mapRow);
-        } catch (final SQLException e) {
-            throw new PersistenceException("SQL 실행 중 오류가 발생했습니다.", e);
-        }
-
+        return jdbcTemplate.queryForObject(query, entityRowMapper::mapRow);
     }
 
     public String renderSelect(final Object id) {

--- a/src/main/java/persistence/entity/EntityLoader.java
+++ b/src/main/java/persistence/entity/EntityLoader.java
@@ -1,19 +1,28 @@
 package persistence.entity;
 
 import jdbc.JdbcTemplate;
+import persistence.core.EntityColumn;
+import persistence.core.EntityColumns;
+import persistence.core.EntityMetadata;
+import persistence.core.EntityMetadataProvider;
 import persistence.sql.dml.DmlGenerator;
 
 public class EntityLoader<T> {
+    private final String tableName;
+    private final EntityColumn idColumn;
+    private final EntityColumns columns;
     private final DmlGenerator dmlGenerator;
     private final JdbcTemplate jdbcTemplate;
-    private final EntityPersister entityPersister;
     private final EntityRowMapper<T> entityRowMapper;
 
-    public EntityLoader(final Class<T> clazz, final DmlGenerator dmlGenerator, final JdbcTemplate jdbcTemplate, final EntityPersister entityPersister) {
-        this.entityPersister = entityPersister;
+    public EntityLoader(final Class<T> clazz, final DmlGenerator dmlGenerator, final JdbcTemplate jdbcTemplate) {
+        final EntityMetadata<T> entityMetadata = EntityMetadataProvider.getInstance().getEntityMetadata(clazz);
+        this.tableName = entityMetadata.getTableName();
+        this.idColumn = entityMetadata.getIdColumn();
+        this.columns = entityMetadata.getColumns();
         this.dmlGenerator = dmlGenerator;
         this.jdbcTemplate = jdbcTemplate;
-        this.entityRowMapper = new EntityRowMapper<>(clazz, entityPersister);
+        this.entityRowMapper = new EntityRowMapper<>(clazz);
     }
 
     public T loadById(final Object id) {
@@ -22,6 +31,6 @@ public class EntityLoader<T> {
     }
 
     public String renderSelect(final Object id) {
-        return dmlGenerator.findById(entityPersister.getTableName(), entityPersister.getColumnNames(), entityPersister.getIdColumnName(), id);
+        return dmlGenerator.findById(tableName, columns.getNames(), idColumn.getName(), id);
     }
 }

--- a/src/main/java/persistence/entity/EntityLoaderProvider.java
+++ b/src/main/java/persistence/entity/EntityLoaderProvider.java
@@ -1,0 +1,27 @@
+package persistence.entity;
+
+import persistence.core.PersistenceEnvironment;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class EntityLoaderProvider {
+
+    private final Map<Class<?>, EntityLoader<?>> cache;
+    private final PersistenceEnvironment persistenceEnvironment;
+    private final EntityPersisterProvider entityPersisterProvider;
+
+    public EntityLoaderProvider(final PersistenceEnvironment persistenceEnvironment, final EntityPersisterProvider entityPersisterProvider) {
+        this.persistenceEnvironment = persistenceEnvironment;
+        this.entityPersisterProvider = entityPersisterProvider;
+        this.cache = new ConcurrentHashMap<>();
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> EntityLoader<T> getEntityLoader(final Class<T> clazz) {
+        return (EntityLoader<T>) cache.computeIfAbsent(clazz, cls ->
+                new EntityLoader<T>(clazz, persistenceEnvironment, entityPersisterProvider.getEntityPersister(clazz))
+        );
+    }
+
+}

--- a/src/main/java/persistence/entity/EntityLoaderProvider.java
+++ b/src/main/java/persistence/entity/EntityLoaderProvider.java
@@ -1,6 +1,7 @@
 package persistence.entity;
 
-import persistence.core.PersistenceEnvironment;
+import jdbc.JdbcTemplate;
+import persistence.sql.dml.DmlGenerator;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -8,11 +9,13 @@ import java.util.concurrent.ConcurrentHashMap;
 public class EntityLoaderProvider {
 
     private final Map<Class<?>, EntityLoader<?>> cache;
-    private final PersistenceEnvironment persistenceEnvironment;
+    private final DmlGenerator dmlGenerator;
+    private final JdbcTemplate jdbcTemplate;
     private final EntityPersisterProvider entityPersisterProvider;
 
-    public EntityLoaderProvider(final PersistenceEnvironment persistenceEnvironment, final EntityPersisterProvider entityPersisterProvider) {
-        this.persistenceEnvironment = persistenceEnvironment;
+    public EntityLoaderProvider(final DmlGenerator dmlGenerator, final JdbcTemplate jdbcTemplate, final EntityPersisterProvider entityPersisterProvider) {
+        this.dmlGenerator = dmlGenerator;
+        this.jdbcTemplate = jdbcTemplate;
         this.entityPersisterProvider = entityPersisterProvider;
         this.cache = new ConcurrentHashMap<>();
     }
@@ -20,7 +23,7 @@ public class EntityLoaderProvider {
     @SuppressWarnings("unchecked")
     public <T> EntityLoader<T> getEntityLoader(final Class<T> clazz) {
         return (EntityLoader<T>) cache.computeIfAbsent(clazz, cls ->
-                new EntityLoader<>(clazz, persistenceEnvironment, entityPersisterProvider.getEntityPersister(clazz))
+                new EntityLoader<>(clazz, dmlGenerator, jdbcTemplate, entityPersisterProvider.getEntityPersister(clazz))
         );
     }
 

--- a/src/main/java/persistence/entity/EntityLoaderProvider.java
+++ b/src/main/java/persistence/entity/EntityLoaderProvider.java
@@ -11,16 +11,16 @@ public class EntityLoaderProvider {
     private final PersistenceEnvironment persistenceEnvironment;
     private final EntityPersisterProvider entityPersisterProvider;
 
-    public EntityLoaderProvider(final PersistenceEnvironment persistenceEnvironment, final EntityPersisterProvider entityPersisterProvider) {
+    public EntityLoaderProvider(final PersistenceEnvironment persistenceEnvironment) {
         this.persistenceEnvironment = persistenceEnvironment;
-        this.entityPersisterProvider = entityPersisterProvider;
+        this.entityPersisterProvider = persistenceEnvironment.getEntityPersisterProvider();
         this.cache = new ConcurrentHashMap<>();
     }
 
     @SuppressWarnings("unchecked")
     public <T> EntityLoader<T> getEntityLoader(final Class<T> clazz) {
         return (EntityLoader<T>) cache.computeIfAbsent(clazz, cls ->
-                new EntityLoader<T>(clazz, persistenceEnvironment, entityPersisterProvider.getEntityPersister(clazz))
+                new EntityLoader<>(clazz, persistenceEnvironment, entityPersisterProvider.getEntityPersister(clazz))
         );
     }
 

--- a/src/main/java/persistence/entity/EntityLoaderProvider.java
+++ b/src/main/java/persistence/entity/EntityLoaderProvider.java
@@ -11,19 +11,17 @@ public class EntityLoaderProvider {
     private final Map<Class<?>, EntityLoader<?>> cache;
     private final DmlGenerator dmlGenerator;
     private final JdbcTemplate jdbcTemplate;
-    private final EntityPersisterProvider entityPersisterProvider;
 
-    public EntityLoaderProvider(final DmlGenerator dmlGenerator, final JdbcTemplate jdbcTemplate, final EntityPersisterProvider entityPersisterProvider) {
+    public EntityLoaderProvider(final DmlGenerator dmlGenerator, final JdbcTemplate jdbcTemplate) {
         this.dmlGenerator = dmlGenerator;
         this.jdbcTemplate = jdbcTemplate;
-        this.entityPersisterProvider = entityPersisterProvider;
         this.cache = new ConcurrentHashMap<>();
     }
 
     @SuppressWarnings("unchecked")
     public <T> EntityLoader<T> getEntityLoader(final Class<T> clazz) {
         return (EntityLoader<T>) cache.computeIfAbsent(clazz, cls ->
-                new EntityLoader<>(clazz, dmlGenerator, jdbcTemplate, entityPersisterProvider.getEntityPersister(clazz))
+                new EntityLoader<>(clazz, dmlGenerator, jdbcTemplate)
         );
     }
 

--- a/src/main/java/persistence/entity/EntityLoaderProvider.java
+++ b/src/main/java/persistence/entity/EntityLoaderProvider.java
@@ -11,9 +11,9 @@ public class EntityLoaderProvider {
     private final PersistenceEnvironment persistenceEnvironment;
     private final EntityPersisterProvider entityPersisterProvider;
 
-    public EntityLoaderProvider(final PersistenceEnvironment persistenceEnvironment) {
+    public EntityLoaderProvider(final PersistenceEnvironment persistenceEnvironment, final EntityPersisterProvider entityPersisterProvider) {
         this.persistenceEnvironment = persistenceEnvironment;
-        this.entityPersisterProvider = persistenceEnvironment.getEntityPersisterProvider();
+        this.entityPersisterProvider = entityPersisterProvider;
         this.cache = new ConcurrentHashMap<>();
     }
 

--- a/src/main/java/persistence/entity/EntityManager.java
+++ b/src/main/java/persistence/entity/EntityManager.java
@@ -8,5 +8,4 @@ public interface EntityManager {
 
     void remove(Object entity);
 
-    void close();
 }

--- a/src/main/java/persistence/entity/EntityPersister.java
+++ b/src/main/java/persistence/entity/EntityPersister.java
@@ -30,32 +30,17 @@ public class EntityPersister {
 
     public void insert(final Object entity) {
         final String insertQuery = renderInsert(entity);
-        try (final Connection connection = persistenceEnvironment.getConnection()) {
-            final JdbcTemplate jdbcTemplate = new JdbcTemplate(connection);
-            jdbcTemplate.execute(insertQuery);
-        } catch (final SQLException e) {
-            throw new PersistenceException("SQL 실행 중 오류가 발생했습니다.", e);
-        }
+        executeQuery(insertQuery);
     }
 
     public void update(final Object entity) {
         final String updateQuery = renderUpdate(entity);
-        try (final Connection connection = persistenceEnvironment.getConnection()) {
-            final JdbcTemplate jdbcTemplate = new JdbcTemplate(connection);
-            jdbcTemplate.execute(updateQuery);
-        } catch (final SQLException e) {
-            throw new PersistenceException("SQL 실행 중 오류가 발생했습니다.", e);
-        }
+        executeQuery(updateQuery);
     }
 
     public void delete(final Object entity) {
         final String deleteQuery = renderDelete(entity);
-        try (final Connection connection = persistenceEnvironment.getConnection()) {
-            final JdbcTemplate jdbcTemplate = new JdbcTemplate(connection);
-            jdbcTemplate.execute(deleteQuery);
-        } catch (final SQLException e) {
-            throw new PersistenceException("SQL 실행 중 오류가 발생했습니다.", e);
-        }
+        executeQuery(deleteQuery);
     }
 
     public String renderInsert(final Object entity) {
@@ -94,5 +79,14 @@ public class EntityPersister {
 
     public String getIdColumnName() {
         return idColumn.getName();
+    }
+
+    private void executeQuery(final String query) {
+        try (final Connection connection = persistenceEnvironment.getConnection()) {
+            final JdbcTemplate jdbcTemplate = new JdbcTemplate(connection);
+            jdbcTemplate.execute(query);
+        } catch (final SQLException e) {
+            throw new PersistenceException("SQL 실행 중 오류가 발생했습니다.", e);
+        }
     }
 }

--- a/src/main/java/persistence/entity/EntityPersister.java
+++ b/src/main/java/persistence/entity/EntityPersister.java
@@ -43,7 +43,7 @@ public class EntityPersister {
         jdbcTemplate.execute(deleteQuery);
     }
 
-    public String renderSelect(final Long id) {
+    public String renderSelect(final Object id) {
         return dmlGenerator.findById(tableName, columns.getNames(), idColumn.getName(), id);
     }
 
@@ -63,6 +63,18 @@ public class EntityPersister {
     public String renderDelete(final Object entity) {
         final Object idValue = ReflectionUtils.getFieldValue(entity, idColumn.getFieldName());
         return dmlGenerator.delete(tableName, idColumn.getName(), idValue);
+    }
+
+    public List<String> getColumnNames() {
+        return columns.getNames();
+    }
+
+    public List<String> getColumnFieldNames() {
+        return columns.getFieldNames();
+    }
+
+    public int getColumnSize() {
+        return columns.size();
     }
 
 }

--- a/src/main/java/persistence/entity/EntityPersister.java
+++ b/src/main/java/persistence/entity/EntityPersister.java
@@ -43,10 +43,6 @@ public class EntityPersister {
         jdbcTemplate.execute(deleteQuery);
     }
 
-    public String renderSelect(final Object id) {
-        return dmlGenerator.findById(tableName, columns.getNames(), idColumn.getName(), id);
-    }
-
     public String renderInsert(final Object entity) {
         final List<String> columnNames = insertableColumns.getNames();
         final List<Object> values = ReflectionUtils.getFieldValues(entity, insertableColumns.getFieldNames());
@@ -77,4 +73,11 @@ public class EntityPersister {
         return columns.size();
     }
 
+    public String getTableName() {
+        return tableName;
+    }
+
+    public String getIdColumnName() {
+        return idColumn.getName();
+    }
 }

--- a/src/main/java/persistence/entity/EntityPersisterProvider.java
+++ b/src/main/java/persistence/entity/EntityPersisterProvider.java
@@ -1,6 +1,7 @@
 package persistence.entity;
 
-import persistence.core.PersistenceEnvironment;
+import jdbc.JdbcTemplate;
+import persistence.sql.dml.DmlGenerator;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -8,16 +9,18 @@ import java.util.concurrent.ConcurrentHashMap;
 public class EntityPersisterProvider {
 
     private final Map<Class<?>, EntityPersister> cache;
-    private final PersistenceEnvironment persistenceEnvironment;
+    private final DmlGenerator dmlGenerator;
+    private final JdbcTemplate jdbcTemplate;
 
-    public EntityPersisterProvider(final PersistenceEnvironment persistenceEnvironment) {
-        this.persistenceEnvironment = persistenceEnvironment;
+    public EntityPersisterProvider(final DmlGenerator dmlGenerator, final JdbcTemplate jdbcTemplate) {
+        this.dmlGenerator = dmlGenerator;
+        this.jdbcTemplate = jdbcTemplate;
         this.cache = new ConcurrentHashMap<>();
     }
 
     public EntityPersister getEntityPersister(final Class<?> clazz) {
-        return cache.computeIfAbsent(clazz, cls->
-            new EntityPersister(clazz, persistenceEnvironment)
+        return cache.computeIfAbsent(clazz, cls ->
+                new EntityPersister(clazz, dmlGenerator, jdbcTemplate)
         );
     }
 

--- a/src/main/java/persistence/entity/EntityPersisterProvider.java
+++ b/src/main/java/persistence/entity/EntityPersisterProvider.java
@@ -1,7 +1,6 @@
 package persistence.entity;
 
-import jdbc.JdbcTemplate;
-import persistence.sql.dml.DmlGenerator;
+import persistence.core.PersistenceEnvironment;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -9,18 +8,16 @@ import java.util.concurrent.ConcurrentHashMap;
 public class EntityPersisterProvider {
 
     private final Map<Class<?>, EntityPersister> cache;
-    private final JdbcTemplate jdbcTemplate;
-    private final DmlGenerator dmlGenerator;
+    private final PersistenceEnvironment persistenceEnvironment;
 
-    public EntityPersisterProvider(final JdbcTemplate jdbcTemplate, final DmlGenerator dmlGenerator) {
-        this.jdbcTemplate = jdbcTemplate;
-        this.dmlGenerator = dmlGenerator;
+    public EntityPersisterProvider(final PersistenceEnvironment persistenceEnvironment) {
+        this.persistenceEnvironment = persistenceEnvironment;
         this.cache = new ConcurrentHashMap<>();
     }
 
     public EntityPersister getEntityPersister(final Class<?> clazz) {
         return cache.computeIfAbsent(clazz, cls->
-            new EntityPersister(clazz, jdbcTemplate, dmlGenerator)
+            new EntityPersister(clazz, persistenceEnvironment)
         );
     }
 

--- a/src/main/java/persistence/entity/EntityRowMapper.java
+++ b/src/main/java/persistence/entity/EntityRowMapper.java
@@ -1,5 +1,7 @@
 package persistence.entity;
 
+import persistence.core.EntityMetadata;
+import persistence.core.EntityMetadataProvider;
 import persistence.exception.PersistenceException;
 import persistence.util.ReflectionUtils;
 
@@ -13,11 +15,12 @@ public class EntityRowMapper<T> {
     private final List<String> fieldNames;
     private final int columnSize;
 
-    public EntityRowMapper(final Class<T> clazz, final EntityPersister entityPersister) {
+    public EntityRowMapper(final Class<T> clazz) {
+        final EntityMetadata<T> entityMetadata = EntityMetadataProvider.getInstance().getEntityMetadata(clazz);
         this.clazz = clazz;
-        this.columnNames = entityPersister.getColumnNames();
-        this.fieldNames = entityPersister.getColumnFieldNames();
-        this.columnSize = entityPersister.getColumnSize();
+        this.columnNames = entityMetadata.getColumnNames();
+        this.fieldNames = entityMetadata.getColumnFieldNames();
+        this.columnSize = entityMetadata.getColumnSize();
     }
 
     public T mapRow(final ResultSet resultSet) {

--- a/src/main/java/persistence/entity/EntityRowMapper.java
+++ b/src/main/java/persistence/entity/EntityRowMapper.java
@@ -1,0 +1,38 @@
+package persistence.entity;
+
+import persistence.exception.PersistenceException;
+import persistence.util.ReflectionUtils;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+public class EntityRowMapper<T> {
+    private final Class<T> clazz;
+    private final List<String> columnNames;
+    private final List<String> fieldNames;
+    private final int columnSize;
+
+    public EntityRowMapper(final Class<T> clazz, final EntityPersister entityPersister) {
+        this.clazz = clazz;
+        this.columnNames = entityPersister.getColumnNames();
+        this.fieldNames = entityPersister.getColumnFieldNames();
+        this.columnSize = entityPersister.getColumnSize();
+    }
+
+    public T mapRow(final ResultSet resultSet) {
+        try {
+            final T instance = ReflectionUtils.createInstance(clazz);
+            for (int i = 0; i < columnSize; i++) {
+                final String fieldName = fieldNames.get(i);
+                final String columnName = columnNames.get(i);
+                final Object object;
+                object = resultSet.getObject(columnName);
+                ReflectionUtils.injectField(instance, fieldName, object);
+            }
+            return instance;
+        } catch (final SQLException e) {
+            throw new PersistenceException("ResultSet Mapping 중 에러가 발생했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/persistence/entity/SimpleEntityManager.java
+++ b/src/main/java/persistence/entity/SimpleEntityManager.java
@@ -1,54 +1,33 @@
 package persistence.entity;
 
-import jdbc.JdbcTemplate;
 import persistence.core.PersistenceEnvironment;
-import persistence.exception.PersistenceException;
-import persistence.sql.dml.DmlGenerator;
-
-import java.sql.Connection;
-import java.sql.SQLException;
 
 public class SimpleEntityManager implements EntityManager {
 
-    private final JdbcTemplate jdbcTemplate;
-    private final Connection connection;
-    private boolean closed;
     private final EntityPersisterProvider entityPersisterProvider;
-    private final DmlGenerator dmlGenerator;
+    private final EntityLoaderProvider entityLoaderProvider;
 
     public SimpleEntityManager(final PersistenceEnvironment persistenceEnvironment) {
-        this.connection = persistenceEnvironment.getConnection();
-        this.jdbcTemplate = new JdbcTemplate(connection);
-        this.closed = false;
-        this.dmlGenerator = persistenceEnvironment.getDmlGenerator();
-        this.entityPersisterProvider = new EntityPersisterProvider(jdbcTemplate, dmlGenerator);
+        this.entityPersisterProvider = persistenceEnvironment.getEntityPersisterProvider();
+        this.entityLoaderProvider = persistenceEnvironment.getEntityLoaderProvider();
     }
 
     @Override
     public <T> T find(final Class<T> clazz, final Long id) {
-        checkConnectionOpen();
-        final EntityPersister entityPersister = entityPersisterProvider.getEntityPersister(clazz);
-        final EntityLoader<T> entityLoader = new EntityLoader<>(clazz, entityPersister, jdbcTemplate, dmlGenerator);
+        final EntityLoader<T> entityLoader = entityLoaderProvider.getEntityLoader(clazz);
         return entityLoader.loadById(id);
     }
 
     @Override
     public void persist(final Object entity) {
-        checkConnectionOpen();
         final EntityPersister entityPersister = entityPersisterProvider.getEntityPersister(entity.getClass());
         entityPersister.insert(entity);
     }
 
     @Override
     public void remove(final Object entity) {
-        checkConnectionOpen();
         final EntityPersister entityPersister = entityPersisterProvider.getEntityPersister(entity.getClass());
         entityPersister.delete(entity);
     }
 
-    private void checkConnectionOpen() {
-        if (this.closed) {
-            throw new PersistenceException("DB와의 커넥션이 끊어졌습니다.");
-        }
-    }
 }

--- a/src/main/java/persistence/entity/SimpleEntityManager.java
+++ b/src/main/java/persistence/entity/SimpleEntityManager.java
@@ -1,15 +1,13 @@
 package persistence.entity;
 
-import persistence.core.PersistenceEnvironment;
-
 public class SimpleEntityManager implements EntityManager {
 
     private final EntityPersisterProvider entityPersisterProvider;
     private final EntityLoaderProvider entityLoaderProvider;
 
-    public SimpleEntityManager(final PersistenceEnvironment persistenceEnvironment) {
-        this.entityPersisterProvider = persistenceEnvironment.getEntityPersisterProvider();
-        this.entityLoaderProvider = persistenceEnvironment.getEntityLoaderProvider();
+    public SimpleEntityManager(final EntityPersisterProvider entityPersisterProvider, final EntityLoaderProvider entityLoaderProvider) {
+        this.entityPersisterProvider = entityPersisterProvider;
+        this.entityLoaderProvider = entityLoaderProvider;
     }
 
     @Override

--- a/src/main/java/persistence/entity/SimpleEntityManager.java
+++ b/src/main/java/persistence/entity/SimpleEntityManager.java
@@ -46,17 +46,6 @@ public class SimpleEntityManager implements EntityManager {
         entityPersister.delete(entity);
     }
 
-    @Override
-    public void close() {
-        try {
-            connection.close();
-        } catch (final SQLException e) {
-            throw new PersistenceException("커넥션 닫기를 실패했습니다.", e);
-        } finally {
-            this.closed = true;
-        }
-    }
-
     private void checkConnectionOpen() {
         if (this.closed) {
             throw new PersistenceException("DB와의 커넥션이 끊어졌습니다.");

--- a/src/test/java/mock/MockDatabaseServer.java
+++ b/src/test/java/mock/MockDatabaseServer.java
@@ -1,4 +1,6 @@
-package database;
+package mock;
+
+import database.DatabaseServer;
 
 import java.sql.Connection;
 import java.sql.SQLException;

--- a/src/test/java/mock/MockDmlGenerator.java
+++ b/src/test/java/mock/MockDmlGenerator.java
@@ -1,0 +1,10 @@
+package mock;
+
+import persistence.dialect.h2.H2Dialect;
+import persistence.sql.dml.DmlGenerator;
+
+public class MockDmlGenerator extends DmlGenerator {
+    public MockDmlGenerator() {
+        super(new H2Dialect());
+    }
+}

--- a/src/test/java/mock/MockEntityPersister.java
+++ b/src/test/java/mock/MockEntityPersister.java
@@ -1,0 +1,12 @@
+package mock;
+
+import persistence.entity.EntityPersister;
+
+import java.sql.SQLException;
+
+public class MockEntityPersister extends EntityPersister {
+    public MockEntityPersister(final Class<?> clazz) throws SQLException {
+        super(clazz, new MockJdbcTemplate(), new MockDmlGenerator());
+    }
+
+}

--- a/src/test/java/mock/MockEntityPersister.java
+++ b/src/test/java/mock/MockEntityPersister.java
@@ -2,11 +2,9 @@ package mock;
 
 import persistence.entity.EntityPersister;
 
-import java.sql.SQLException;
-
 public class MockEntityPersister extends EntityPersister {
-    public MockEntityPersister(final Class<?> clazz) throws SQLException {
-        super(clazz, new MockJdbcTemplate(), new MockDmlGenerator());
+    public MockEntityPersister(final Class<?> clazz) {
+        super(clazz, new MockPersistenceEnvironment());
     }
 
 }

--- a/src/test/java/mock/MockEntityPersister.java
+++ b/src/test/java/mock/MockEntityPersister.java
@@ -2,9 +2,11 @@ package mock;
 
 import persistence.entity.EntityPersister;
 
+import java.sql.SQLException;
+
 public class MockEntityPersister extends EntityPersister {
-    public MockEntityPersister(final Class<?> clazz) {
-        super(clazz, new MockPersistenceEnvironment());
+    public MockEntityPersister(final Class<?> clazz) throws SQLException {
+        super(clazz, new MockDmlGenerator(), new MockJdbcTemplate());
     }
 
 }

--- a/src/test/java/mock/MockJdbcTemplate.java
+++ b/src/test/java/mock/MockJdbcTemplate.java
@@ -1,4 +1,4 @@
-package database;
+package mock;
 
 import jdbc.JdbcTemplate;
 

--- a/src/test/java/mock/MockPersistenceEnvironment.java
+++ b/src/test/java/mock/MockPersistenceEnvironment.java
@@ -1,0 +1,11 @@
+package mock;
+
+import persistence.core.PersistenceEnvironment;
+import persistence.dialect.h2.H2Dialect;
+
+public class MockPersistenceEnvironment extends PersistenceEnvironment {
+
+    public MockPersistenceEnvironment() {
+        super(new MockDatabaseServer(), new H2Dialect());
+    }
+}

--- a/src/test/java/persistence/ApplicationTest.java
+++ b/src/test/java/persistence/ApplicationTest.java
@@ -44,16 +44,16 @@ class ApplicationTest {
         server.start();
         jdbcTemplate = new JdbcTemplate(server.getConnection());
         final PersistenceEnvironment persistenceEnvironment = new PersistenceEnvironment(server, new H2Dialect());
-        final EntityPersisterProvider entityPersisterProvider = new EntityPersisterProvider(persistenceEnvironment.getDmlGenerator(), jdbcTemplate);
-        final EntityLoaderProvider entityLoaderProvider = new EntityLoaderProvider(persistenceEnvironment, entityPersisterProvider);
-        entityManager = new SimpleEntityManager(entityPersisterProvider, entityLoaderProvider);
         ddlGenerator = new DdlGenerator(persistenceEnvironment.getDialect());
         dmlGenerator = new DmlGenerator(persistenceEnvironment.getDialect());
+        final EntityPersisterProvider entityPersisterProvider = new EntityPersisterProvider(dmlGenerator, jdbcTemplate);
+        final EntityLoaderProvider entityLoaderProvider = new EntityLoaderProvider(dmlGenerator, jdbcTemplate, entityPersisterProvider);
+        entityManager = new SimpleEntityManager(entityPersisterProvider, entityLoaderProvider);
+
         entityMetadata = EntityMetadataProvider.getInstance().getEntityMetadata(Person.class);
         final String createDdl = ddlGenerator.generateCreateDdl(entityMetadata);
         jdbcTemplate.execute(createDdl);
         people = createDummyUsers();
-
 
         people.forEach(person -> {
             final List<String> columnNames = entityMetadata.getInsertableColumnNames();

--- a/src/test/java/persistence/ApplicationTest.java
+++ b/src/test/java/persistence/ApplicationTest.java
@@ -47,7 +47,7 @@ class ApplicationTest {
         ddlGenerator = new DdlGenerator(persistenceEnvironment.getDialect());
         dmlGenerator = new DmlGenerator(persistenceEnvironment.getDialect());
         final EntityPersisterProvider entityPersisterProvider = new EntityPersisterProvider(dmlGenerator, jdbcTemplate);
-        final EntityLoaderProvider entityLoaderProvider = new EntityLoaderProvider(dmlGenerator, jdbcTemplate, entityPersisterProvider);
+        final EntityLoaderProvider entityLoaderProvider = new EntityLoaderProvider(dmlGenerator, jdbcTemplate);
         entityManager = new SimpleEntityManager(entityPersisterProvider, entityLoaderProvider);
 
         entityMetadata = EntityMetadataProvider.getInstance().getEntityMetadata(Person.class);

--- a/src/test/java/persistence/ApplicationTest.java
+++ b/src/test/java/persistence/ApplicationTest.java
@@ -15,7 +15,6 @@ import persistence.core.PersistenceEnvironment;
 import persistence.dialect.h2.H2Dialect;
 import persistence.entity.EntityManager;
 import persistence.entity.SimpleEntityManager;
-import persistence.exception.PersistenceException;
 import persistence.sql.ddl.DdlGenerator;
 import persistence.sql.dml.DmlGenerator;
 import persistence.util.ReflectionUtils;
@@ -24,7 +23,6 @@ import java.sql.SQLException;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
@@ -54,7 +52,7 @@ class ApplicationTest {
         people.forEach(person -> {
             final List<String> columnNames = entityMetadata.getInsertableColumnNames();
             final List<Object> values = ReflectionUtils.getFieldValues(person, entityMetadata.getInsertableColumnFieldNames());
-            jdbcTemplate.execute(dmlGenerator.insert(entityMetadata.getTableName(), columnNames,values ));
+            jdbcTemplate.execute(dmlGenerator.insert(entityMetadata.getTableName(), columnNames, values));
         });
     }
 
@@ -116,28 +114,6 @@ class ApplicationTest {
         final EntityManager entityManager = new SimpleEntityManager(persistenceEnvironment);
 
         assertDoesNotThrow(() -> entityManager.remove(people.get(0)));
-    }
-
-    @Test
-    @DisplayName("entityManager.close 를 이용해 DB Connection 을 닫을 수 있다.")
-    void connectionCloseTest() {
-        final EntityManager entityManager = new SimpleEntityManager(persistenceEnvironment);
-
-        assertDoesNotThrow(entityManager::close);
-    }
-
-    @Test
-    @DisplayName("entityManager.close 를 이용해 DB Connection 을 닫힌 후 에는 아무 작업을 할 수 없다.")
-    void connectionAlreadyCloseTest() {
-        final EntityManager entityManager = new SimpleEntityManager(persistenceEnvironment);
-
-        entityManager.close();
-
-        assertThatThrownBy(() -> {
-            entityManager.find(Person.class, 1L);
-            entityManager.persist(people.get(0));
-            entityManager.remove(people.get(0));
-        }).isInstanceOf(PersistenceException.class);
     }
 
     private RowMapper<Person> personRowMapper() {

--- a/src/test/java/persistence/ApplicationTest.java
+++ b/src/test/java/persistence/ApplicationTest.java
@@ -31,7 +31,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 class ApplicationTest {
     private DatabaseServer server;
     private JdbcTemplate jdbcTemplate;
-    private PersistenceEnvironment persistenceEnvironment;
     private DdlGenerator ddlGenerator;
     private DmlGenerator dmlGenerator;
     private EntityMetadata<?> entityMetadata;
@@ -45,7 +44,7 @@ class ApplicationTest {
         server.start();
         jdbcTemplate = new JdbcTemplate(server.getConnection());
         final PersistenceEnvironment persistenceEnvironment = new PersistenceEnvironment(server, new H2Dialect());
-        final EntityPersisterProvider entityPersisterProvider = new EntityPersisterProvider(persistenceEnvironment);
+        final EntityPersisterProvider entityPersisterProvider = new EntityPersisterProvider(persistenceEnvironment.getDmlGenerator(), jdbcTemplate);
         final EntityLoaderProvider entityLoaderProvider = new EntityLoaderProvider(persistenceEnvironment, entityPersisterProvider);
         entityManager = new SimpleEntityManager(entityPersisterProvider, entityLoaderProvider);
         ddlGenerator = new DdlGenerator(persistenceEnvironment.getDialect());

--- a/src/test/java/persistence/core/EntityColumnsTest.java
+++ b/src/test/java/persistence/core/EntityColumnsTest.java
@@ -1,8 +1,8 @@
 package persistence.core;
 
+import domain.FixtureEntity;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import domain.FixtureEntity;
 import persistence.exception.ColumnNotExistException;
 
 import static org.assertj.core.api.Assertions.*;
@@ -23,7 +23,7 @@ class EntityColumnsTest {
     @DisplayName("Id 컬럼 정보가 존재하지 않으면 EntityColumns 인스턴스 생성에 실패해야한다.")
     void entityColumnsCreateFailureTest() {
         mockClass = FixtureEntity.WithoutId.class;
-        assertThatThrownBy(()->new EntityColumns(mockClass))
+        assertThatThrownBy(() -> new EntityColumns(mockClass))
                 .isInstanceOf(ColumnNotExistException.class);
     }
 
@@ -45,4 +45,21 @@ class EntityColumnsTest {
         assertThatIterable(columns).doesNotContain(idColumn);
     }
 
+    @Test
+    @DisplayName("EntityColumns.getNames 를 통해 컬럼들의 이름들을 조회할 수 있다.")
+    void entityColumnsGetNamesTest() throws Exception {
+        mockClass = FixtureEntity.WithColumn.class;
+        final EntityColumns columns = new EntityColumns(mockClass);
+
+        assertThatIterable(columns.getNames()).containsExactly("id", "test_column", "notNullColumn");
+    }
+
+    @Test
+    @DisplayName("EntityColumns.getFieldNames 를 통해 컬럼들의 필드 이름들을 조회할 수 있다.")
+    void entityColumnsGetFieldNamesTest() throws Exception {
+        mockClass = FixtureEntity.WithColumn.class;
+        final EntityColumns columns = new EntityColumns(mockClass);
+
+        assertThatIterable(columns.getFieldNames()).containsExactly("id", "column", "notNullColumn");
+    }
 }

--- a/src/test/java/persistence/core/EntityMetadataTest.java
+++ b/src/test/java/persistence/core/EntityMetadataTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import domain.FixtureEntity;
 import persistence.exception.PersistenceException;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class EntityMetadataTest {
@@ -74,6 +74,27 @@ class EntityMetadataTest {
             softly.assertThat(entityMetadata.getColumnFieldNames()).containsExactly("id", "column", "notNullColumn");
         });
     }
+
+    @Test
+    @DisplayName("getIdColumn 를 통해 id column 을 반환 받을 수 있다.")
+    void getIdColumnTest() throws NoSuchFieldException {
+        mockClass = FixtureEntity.WithId.class;
+        final EntityMetadata<?> entityMetadata = new EntityMetadata<>(mockClass);
+        final EntityColumn idColumn = new EntityColumn(mockClass.getDeclaredField("id"));
+
+        assertThat(entityMetadata.getIdColumn()).isEqualTo(idColumn);
+    }
+
+    @Test
+    @DisplayName("getInsertableColumn 를 통해 insertable column 을 반환 받을 수 있다.")
+    void getInsertableColumnTest() throws NoSuchFieldException {
+        mockClass = FixtureEntity.WithColumnNonInsertable.class;
+        final EntityMetadata<?> entityMetadata = new EntityMetadata<>(mockClass);
+        final EntityColumn insertableColumn = new EntityColumn(mockClass.getDeclaredField("insertableColumn"));
+
+        assertThatIterable(entityMetadata.getInsertableColumn()).containsExactly(insertableColumn);
+    }
+
 
     private void assertResult(final EntityMetadata<?> entityMetadata, final String withId, final String id) {
         assertSoftly(softly -> {

--- a/src/test/java/persistence/dialect/PersistenceEnvironmentTest.java
+++ b/src/test/java/persistence/dialect/PersistenceEnvironmentTest.java
@@ -1,6 +1,6 @@
 package persistence.dialect;
 
-import database.MockDatabaseServer;
+import mock.MockDatabaseServer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/persistence/entity/EntityLoaderProviderTest.java
+++ b/src/test/java/persistence/entity/EntityLoaderProviderTest.java
@@ -17,9 +17,7 @@ class EntityLoaderProviderTest {
 
     @BeforeEach
     void setUp() throws SQLException {
-        final MockDmlGenerator dmlGenerator = new MockDmlGenerator();
-        final MockJdbcTemplate jdbcTemplate = new MockJdbcTemplate();
-        entityLoaderProvider = new EntityLoaderProvider(dmlGenerator, jdbcTemplate, new EntityPersisterProvider(dmlGenerator, jdbcTemplate));
+        entityLoaderProvider = new EntityLoaderProvider(new MockDmlGenerator(), new MockJdbcTemplate());
     }
 
     @Test

--- a/src/test/java/persistence/entity/EntityLoaderProviderTest.java
+++ b/src/test/java/persistence/entity/EntityLoaderProviderTest.java
@@ -14,7 +14,8 @@ class EntityLoaderProviderTest {
 
     @BeforeEach
     void setUp() {
-        entityLoaderProvider = new EntityLoaderProvider(new MockPersistenceEnvironment());
+        final MockPersistenceEnvironment persistenceEnvironment = new MockPersistenceEnvironment();
+        entityLoaderProvider = new EntityLoaderProvider(persistenceEnvironment, new EntityPersisterProvider(persistenceEnvironment));
     }
 
     @Test

--- a/src/test/java/persistence/entity/EntityLoaderProviderTest.java
+++ b/src/test/java/persistence/entity/EntityLoaderProviderTest.java
@@ -1,6 +1,7 @@
 package persistence.entity;
 
 import domain.FixtureEntity;
+import jdbc.JdbcTemplate;
 import mock.MockPersistenceEnvironment;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -15,7 +16,7 @@ class EntityLoaderProviderTest {
     @BeforeEach
     void setUp() {
         final MockPersistenceEnvironment persistenceEnvironment = new MockPersistenceEnvironment();
-        entityLoaderProvider = new EntityLoaderProvider(persistenceEnvironment, new EntityPersisterProvider(persistenceEnvironment));
+        entityLoaderProvider = new EntityLoaderProvider(persistenceEnvironment, new EntityPersisterProvider(persistenceEnvironment.getDmlGenerator(), new JdbcTemplate(persistenceEnvironment.getConnection())));
     }
 
     @Test

--- a/src/test/java/persistence/entity/EntityLoaderProviderTest.java
+++ b/src/test/java/persistence/entity/EntityLoaderProviderTest.java
@@ -1,11 +1,13 @@
 package persistence.entity;
 
 import domain.FixtureEntity;
-import jdbc.JdbcTemplate;
-import mock.MockPersistenceEnvironment;
+import mock.MockDmlGenerator;
+import mock.MockJdbcTemplate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,9 +16,10 @@ class EntityLoaderProviderTest {
     private EntityLoaderProvider entityLoaderProvider;
 
     @BeforeEach
-    void setUp() {
-        final MockPersistenceEnvironment persistenceEnvironment = new MockPersistenceEnvironment();
-        entityLoaderProvider = new EntityLoaderProvider(persistenceEnvironment, new EntityPersisterProvider(persistenceEnvironment.getDmlGenerator(), new JdbcTemplate(persistenceEnvironment.getConnection())));
+    void setUp() throws SQLException {
+        final MockDmlGenerator dmlGenerator = new MockDmlGenerator();
+        final MockJdbcTemplate jdbcTemplate = new MockJdbcTemplate();
+        entityLoaderProvider = new EntityLoaderProvider(dmlGenerator, jdbcTemplate, new EntityPersisterProvider(dmlGenerator, jdbcTemplate));
     }
 
     @Test

--- a/src/test/java/persistence/entity/EntityLoaderProviderTest.java
+++ b/src/test/java/persistence/entity/EntityLoaderProviderTest.java
@@ -14,8 +14,7 @@ class EntityLoaderProviderTest {
 
     @BeforeEach
     void setUp() {
-        final MockPersistenceEnvironment persistenceEnvironment = new MockPersistenceEnvironment();
-        entityLoaderProvider = new EntityLoaderProvider(persistenceEnvironment, new EntityPersisterProvider(persistenceEnvironment));
+        entityLoaderProvider = new EntityLoaderProvider(new MockPersistenceEnvironment());
     }
 
     @Test

--- a/src/test/java/persistence/entity/EntityLoaderProviderTest.java
+++ b/src/test/java/persistence/entity/EntityLoaderProviderTest.java
@@ -1,0 +1,38 @@
+package persistence.entity;
+
+import domain.FixtureEntity;
+import mock.MockPersistenceEnvironment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EntityLoaderProviderTest {
+    private Class<FixtureEntity.WithId> fixtureClass;
+    private EntityLoaderProvider entityLoaderProvider;
+
+    @BeforeEach
+    void setUp() {
+        final MockPersistenceEnvironment persistenceEnvironment = new MockPersistenceEnvironment();
+        entityLoaderProvider = new EntityLoaderProvider(persistenceEnvironment, new EntityPersisterProvider(persistenceEnvironment));
+    }
+
+    @Test
+    @DisplayName("EntityLoaderProvider 를 통해 해당 클래스의 EntityLoader 를 사용할 수 있다..")
+    void entityLoaderProviderTest() {
+        fixtureClass = FixtureEntity.WithId.class;
+        final EntityLoader<FixtureEntity.WithId> entityLoader = entityLoaderProvider.getEntityLoader(fixtureClass);
+        assertThat(entityLoader).isNotNull();
+    }
+
+    @Test
+    @DisplayName("EntityLoaderProvider 를 통해 조회된 같은 타입의 EntityLoader 는 같은 객체이다.")
+    void entityLoaderCacheTest() {
+        fixtureClass = FixtureEntity.WithId.class;
+        final EntityLoader<FixtureEntity.WithId> entityLoader = entityLoaderProvider.getEntityLoader(fixtureClass);
+        final EntityLoader<FixtureEntity.WithId> entityLoaderV2 = entityLoaderProvider.getEntityLoader(fixtureClass);
+        assertThat(entityLoader == entityLoaderV2).isTrue();
+    }
+
+}

--- a/src/test/java/persistence/entity/EntityLoaderTest.java
+++ b/src/test/java/persistence/entity/EntityLoaderTest.java
@@ -5,7 +5,6 @@ import jdbc.JdbcTemplate;
 import jdbc.RowMapper;
 import mock.MockDatabaseServer;
 import mock.MockDmlGenerator;
-import mock.MockEntityPersister;
 import org.h2.tools.SimpleResultSet;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -44,7 +43,7 @@ class EntityLoaderTest {
     @DisplayName("loadById 를 통해 객체를 조회할 수 있다.")
     void loadByIdTest() throws SQLException {
         final Class<Person> clazz = Person.class;
-        final EntityLoader<Person> entityLoader = new EntityLoader<>(clazz, new MockDmlGenerator(), new MockJdbcTemplate(), new MockEntityPersister(clazz));
+        final EntityLoader<Person> entityLoader = new EntityLoader<>(clazz, new MockDmlGenerator(), new MockJdbcTemplate());
 
         final Person person = entityLoader.loadById(1L);
 

--- a/src/test/java/persistence/entity/EntityLoaderTest.java
+++ b/src/test/java/persistence/entity/EntityLoaderTest.java
@@ -8,13 +8,15 @@ import org.junit.jupiter.api.Test;
 import persistence.core.PersistenceEnvironment;
 import persistence.dialect.h2.H2Dialect;
 
+import java.sql.SQLException;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class EntityLoaderTest {
 
     @Test
     @DisplayName("renderSelect 을 이용해 entity 의 select 문을 만들 수 있다.")
-    void renderSelectTest() {
+    void renderSelectTest() throws SQLException {
         final Class<Person> clazz = Person.class;
         final EntityLoader<Person> entityLoader = new EntityLoader<>(clazz, new PersistenceEnvironment(new MockDatabaseServer(), new H2Dialect()), new MockEntityPersister(clazz));
         final String query = entityLoader.renderSelect(1L);

--- a/src/test/java/persistence/entity/EntityLoaderTest.java
+++ b/src/test/java/persistence/entity/EntityLoaderTest.java
@@ -1,24 +1,58 @@
 package persistence.entity;
 
 import domain.Person;
+import jdbc.JdbcTemplate;
+import jdbc.RowMapper;
+import mock.MockDatabaseServer;
 import mock.MockDmlGenerator;
 import mock.MockEntityPersister;
-import mock.MockJdbcTemplate;
+import org.h2.tools.SimpleResultSet;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
+import java.sql.Types;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class EntityLoaderTest {
 
+    static class MockJdbcTemplate extends JdbcTemplate {
+        public MockJdbcTemplate() throws SQLException {
+            super(new MockDatabaseServer().getConnection());
+        }
+
+        @Override
+        public <T> T queryForObject(final String sql, final RowMapper<T> rowMapper) {
+            try (final SimpleResultSet rs = new SimpleResultSet()) {
+                rs.addColumn("id", Types.BIGINT, 10, 0);
+                rs.addColumn("nick_name", Types.VARCHAR, 255, 0);
+                rs.addColumn("old", Types.INTEGER, 10, 0);
+                rs.addColumn("email", Types.VARCHAR, 255, 0);
+                rs.addRow(1L, "min", 30, "jongmin4943@gmail.com");
+                if (rs.next()) {
+                    return rowMapper.mapRow(rs);
+                }
+                throw new RuntimeException("Data not exist");
+            } catch (final Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
     @Test
-    @DisplayName("renderSelect 을 이용해 entity 의 select 문을 만들 수 있다.")
-    void renderSelectTest() throws SQLException {
+    @DisplayName("loadById 를 통해 객체를 조회할 수 있다.")
+    void loadByIdTest() throws SQLException {
         final Class<Person> clazz = Person.class;
         final EntityLoader<Person> entityLoader = new EntityLoader<>(clazz, new MockDmlGenerator(), new MockJdbcTemplate(), new MockEntityPersister(clazz));
-        final String query = entityLoader.renderSelect(1L);
-        assertThat(query).isEqualTo("select id, nick_name, old, email from users where id=1");
+
+        final Person person = entityLoader.loadById(1L);
+
+        assertSoftly(softly -> {
+            softly.assertThat(person.getId()).isEqualTo(1L);
+            softly.assertThat(person.getName()).isEqualTo("min");
+            softly.assertThat(person.getAge()).isEqualTo(30);
+            softly.assertThat(person.getEmail()).isEqualTo("jongmin4943@gmail.com");
+        });
     }
 }

--- a/src/test/java/persistence/entity/EntityLoaderTest.java
+++ b/src/test/java/persistence/entity/EntityLoaderTest.java
@@ -1,0 +1,24 @@
+package persistence.entity;
+
+import domain.Person;
+import mock.MockDmlGenerator;
+import mock.MockEntityPersister;
+import mock.MockJdbcTemplate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EntityLoaderTest {
+
+    @Test
+    @DisplayName("renderSelect 을 이용해 entity 의 select 문을 만들 수 있다.")
+    void renderSelectTest() throws SQLException {
+        final Class<Person> clazz = Person.class;
+        final EntityLoader<Person> entityLoader = new EntityLoader<>(clazz, new MockEntityPersister(clazz), new MockJdbcTemplate(), new MockDmlGenerator());
+        final String query = entityLoader.renderSelect(1L);
+        assertThat(query).isEqualTo("select id, nick_name, old, email from users where id=1");
+    }
+}

--- a/src/test/java/persistence/entity/EntityLoaderTest.java
+++ b/src/test/java/persistence/entity/EntityLoaderTest.java
@@ -1,13 +1,12 @@
 package persistence.entity;
 
 import domain.Person;
-import mock.MockDmlGenerator;
+import mock.MockDatabaseServer;
 import mock.MockEntityPersister;
-import mock.MockJdbcTemplate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.sql.SQLException;
+import persistence.core.PersistenceEnvironment;
+import persistence.dialect.h2.H2Dialect;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -15,9 +14,9 @@ class EntityLoaderTest {
 
     @Test
     @DisplayName("renderSelect 을 이용해 entity 의 select 문을 만들 수 있다.")
-    void renderSelectTest() throws SQLException {
+    void renderSelectTest() {
         final Class<Person> clazz = Person.class;
-        final EntityLoader<Person> entityLoader = new EntityLoader<>(clazz, new MockEntityPersister(clazz), new MockJdbcTemplate(), new MockDmlGenerator());
+        final EntityLoader<Person> entityLoader = new EntityLoader<>(clazz, new PersistenceEnvironment(new MockDatabaseServer(), new H2Dialect()), new MockEntityPersister(clazz));
         final String query = entityLoader.renderSelect(1L);
         assertThat(query).isEqualTo("select id, nick_name, old, email from users where id=1");
     }

--- a/src/test/java/persistence/entity/EntityLoaderTest.java
+++ b/src/test/java/persistence/entity/EntityLoaderTest.java
@@ -1,12 +1,11 @@
 package persistence.entity;
 
 import domain.Person;
-import mock.MockDatabaseServer;
+import mock.MockDmlGenerator;
 import mock.MockEntityPersister;
+import mock.MockJdbcTemplate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import persistence.core.PersistenceEnvironment;
-import persistence.dialect.h2.H2Dialect;
 
 import java.sql.SQLException;
 
@@ -18,7 +17,7 @@ class EntityLoaderTest {
     @DisplayName("renderSelect 을 이용해 entity 의 select 문을 만들 수 있다.")
     void renderSelectTest() throws SQLException {
         final Class<Person> clazz = Person.class;
-        final EntityLoader<Person> entityLoader = new EntityLoader<>(clazz, new PersistenceEnvironment(new MockDatabaseServer(), new H2Dialect()), new MockEntityPersister(clazz));
+        final EntityLoader<Person> entityLoader = new EntityLoader<>(clazz, new MockDmlGenerator(), new MockJdbcTemplate(), new MockEntityPersister(clazz));
         final String query = entityLoader.renderSelect(1L);
         assertThat(query).isEqualTo("select id, nick_name, old, email from users where id=1");
     }

--- a/src/test/java/persistence/entity/EntityPersisterProviderTest.java
+++ b/src/test/java/persistence/entity/EntityPersisterProviderTest.java
@@ -1,10 +1,13 @@
 package persistence.entity;
 
 import domain.FixtureEntity;
-import mock.MockPersistenceEnvironment;
+import mock.MockDmlGenerator;
+import mock.MockJdbcTemplate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,8 +16,8 @@ class EntityPersisterProviderTest {
     private EntityPersisterProvider entityPersisterProvider;
 
     @BeforeEach
-    void setUp() {
-        entityPersisterProvider = new EntityPersisterProvider(new MockPersistenceEnvironment());
+    void setUp() throws SQLException {
+        entityPersisterProvider = new EntityPersisterProvider(new MockDmlGenerator(), new MockJdbcTemplate());
     }
 
     @Test

--- a/src/test/java/persistence/entity/EntityPersisterProviderTest.java
+++ b/src/test/java/persistence/entity/EntityPersisterProviderTest.java
@@ -1,6 +1,6 @@
 package persistence.entity;
 
-import database.MockJdbcTemplate;
+import mock.MockJdbcTemplate;
 import domain.FixtureEntity;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/persistence/entity/EntityPersisterProviderTest.java
+++ b/src/test/java/persistence/entity/EntityPersisterProviderTest.java
@@ -1,0 +1,41 @@
+package persistence.entity;
+
+import database.MockJdbcTemplate;
+import domain.FixtureEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import persistence.dialect.h2.H2Dialect;
+import persistence.sql.dml.DmlGenerator;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EntityPersisterProviderTest {
+    private Class<?> fixtureClass;
+    private EntityPersisterProvider entityPersisterProvider;
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        entityPersisterProvider = new EntityPersisterProvider(new MockJdbcTemplate(), new DmlGenerator(new H2Dialect()));
+    }
+
+    @Test
+    @DisplayName("EntityPersisterProvider 를 통해 해당 클래스의 EntityPersister 를 사용할 수 있다..")
+    void entityPersisterProviderTest() {
+        fixtureClass = FixtureEntity.WithId.class;
+        final EntityPersister entityPersister = entityPersisterProvider.getEntityPersister(fixtureClass);
+        assertThat(entityPersister).isNotNull();
+    }
+
+    @Test
+    @DisplayName("EntityPersisterProvider 를 통해 조회된 같은 타입의 EntityMetadata 는 같은 객체이다.")
+    void entityPersisterCacheTest() {
+        fixtureClass = FixtureEntity.WithId.class;
+        final EntityPersister entityPersister = entityPersisterProvider.getEntityPersister(fixtureClass);
+        final EntityPersister entityPersisterV2 = entityPersisterProvider.getEntityPersister(fixtureClass);
+        assertThat(entityPersister == entityPersisterV2).isTrue();
+    }
+
+}

--- a/src/test/java/persistence/entity/EntityPersisterProviderTest.java
+++ b/src/test/java/persistence/entity/EntityPersisterProviderTest.java
@@ -1,14 +1,10 @@
 package persistence.entity;
 
-import mock.MockJdbcTemplate;
 import domain.FixtureEntity;
+import mock.MockPersistenceEnvironment;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import persistence.dialect.h2.H2Dialect;
-import persistence.sql.dml.DmlGenerator;
-
-import java.sql.SQLException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,8 +13,8 @@ class EntityPersisterProviderTest {
     private EntityPersisterProvider entityPersisterProvider;
 
     @BeforeEach
-    void setUp() throws SQLException {
-        entityPersisterProvider = new EntityPersisterProvider(new MockJdbcTemplate(), new DmlGenerator(new H2Dialect()));
+    void setUp() {
+        entityPersisterProvider = new EntityPersisterProvider(new MockPersistenceEnvironment());
     }
 
     @Test
@@ -30,7 +26,7 @@ class EntityPersisterProviderTest {
     }
 
     @Test
-    @DisplayName("EntityPersisterProvider 를 통해 조회된 같은 타입의 EntityMetadata 는 같은 객체이다.")
+    @DisplayName("EntityPersisterProvider 를 통해 조회된 같은 타입의 EntityPersister 는 같은 객체이다.")
     void entityPersisterCacheTest() {
         fixtureClass = FixtureEntity.WithId.class;
         final EntityPersister entityPersister = entityPersisterProvider.getEntityPersister(fixtureClass);

--- a/src/test/java/persistence/entity/EntityPersisterTest.java
+++ b/src/test/java/persistence/entity/EntityPersisterTest.java
@@ -1,6 +1,6 @@
 package persistence.entity;
 
-import database.MockJdbcTemplate;
+import mock.MockJdbcTemplate;
 import domain.FixturePerson;
 import domain.Person;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/persistence/entity/EntityPersisterTest.java
+++ b/src/test/java/persistence/entity/EntityPersisterTest.java
@@ -1,16 +1,12 @@
 package persistence.entity;
 
-import mock.MockJdbcTemplate;
 import domain.FixturePerson;
 import domain.Person;
+import mock.MockPersistenceEnvironment;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import persistence.dialect.Dialect;
-import persistence.dialect.h2.H2Dialect;
-import persistence.sql.dml.DmlGenerator;
 
-import java.sql.SQLException;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,9 +18,8 @@ class EntityPersisterTest {
     private Person fixturePerson;
 
     @BeforeEach
-    void setUp() throws SQLException {
-        final Dialect dialect = new H2Dialect();
-        entityPersister = new EntityPersister(Person.class, new MockJdbcTemplate(), new DmlGenerator(dialect));
+    void setUp() {
+        entityPersister = new EntityPersister(Person.class, new MockPersistenceEnvironment());
         fixturePerson = FixturePerson.create(1L);
     }
 

--- a/src/test/java/persistence/entity/EntityPersisterTest.java
+++ b/src/test/java/persistence/entity/EntityPersisterTest.java
@@ -29,13 +29,6 @@ class EntityPersisterTest {
     }
 
     @Test
-    @DisplayName("renderSelect 을 이용해 entity 의 select 문을 만들 수 있다.")
-    void renderSelectTest() {
-        final String query = entityPersister.renderSelect(1L);
-        assertThat(query).isEqualTo("select id, nick_name, old, email from users where id=1");
-    }
-
-    @Test
     @DisplayName("renderInsert 를 이용해 entity 의 insert 문을 만들 수 있다.")
     void renderInsertTest() {
         final String query = entityPersister.renderInsert(fixturePerson);

--- a/src/test/java/persistence/entity/EntityPersisterTest.java
+++ b/src/test/java/persistence/entity/EntityPersisterTest.java
@@ -2,11 +2,13 @@ package persistence.entity;
 
 import domain.FixturePerson;
 import domain.Person;
-import mock.MockPersistenceEnvironment;
+import mock.MockDmlGenerator;
+import mock.MockJdbcTemplate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.sql.SQLException;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,8 +20,8 @@ class EntityPersisterTest {
     private Person fixturePerson;
 
     @BeforeEach
-    void setUp() {
-        entityPersister = new EntityPersister(Person.class, new MockPersistenceEnvironment());
+    void setUp() throws SQLException {
+        entityPersister = new EntityPersister(Person.class, new MockDmlGenerator(), new MockJdbcTemplate());
         fixturePerson = FixturePerson.create(1L);
     }
 

--- a/src/test/java/persistence/entity/EntityPersisterTest.java
+++ b/src/test/java/persistence/entity/EntityPersisterTest.java
@@ -11,8 +11,10 @@ import persistence.dialect.h2.H2Dialect;
 import persistence.sql.dml.DmlGenerator;
 
 import java.sql.SQLException;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIterable;
 
 class EntityPersisterTest {
 
@@ -53,6 +55,30 @@ class EntityPersisterTest {
     void renderDeleteTest() {
         final String query = entityPersister.renderDelete(fixturePerson);
         assertThat(query).isEqualTo("delete from users where id=1");
+    }
+
+    @Test
+    @DisplayName("getColumnNames 을 이용해 entity 의 column 이름들을 반환 받을 수 있다.")
+    void getColumnNamesTest() {
+        final List<String> columnNames = entityPersister.getColumnNames();
+
+        assertThatIterable(columnNames).containsExactly("id", "nick_name", "old", "email");
+    }
+
+    @Test
+    @DisplayName("getColumnFieldNames 을 이용해 entity 의 필드 이름들을 반환 받을 수 있다.")
+    void getColumnFieldNamesTest() {
+        final List<String> columnFieldNames = entityPersister.getColumnFieldNames();
+
+        assertThatIterable(columnFieldNames).containsExactly("id", "name", "age", "email");
+    }
+
+    @Test
+    @DisplayName("getColumnSize 을 이용해 entity 의 필드 갯수를 반환 받을 수 있다.")
+    void getColumnSizeTest() {
+        final int size = entityPersister.getColumnSize();
+
+        assertThat(size).isEqualTo(4);
     }
 
 }

--- a/src/test/java/persistence/entity/EntityRowMapperTest.java
+++ b/src/test/java/persistence/entity/EntityRowMapperTest.java
@@ -1,0 +1,47 @@
+package persistence.entity;
+
+
+import domain.Person;
+import mock.MockEntityPersister;
+import org.h2.tools.SimpleResultSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+import java.sql.Types;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+class EntityRowMapperTest {
+
+    private EntityRowMapper<Person> entityRowMapper;
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        final Class<Person> clazz = Person.class;
+        final EntityPersister entityPersister = new MockEntityPersister(clazz);
+        entityRowMapper = new EntityRowMapper<>(clazz, entityPersister);
+    }
+
+    @Test
+    @DisplayName("EntityRowMapper 를 이용해 객체를 ResultSet 으로 부터 생성 할 수 있다.")
+    void rowMappingTest() throws SQLException {
+        final SimpleResultSet rs = new SimpleResultSet();
+        rs.addColumn("id", Types.BIGINT, 10, 0);
+        rs.addColumn("nick_name", Types.VARCHAR, 255, 0);
+        rs.addColumn("old", Types.INTEGER, 10, 0);
+        rs.addColumn("email", Types.VARCHAR, 255, 0);
+        rs.addRow(1L, "min", 30, "jongmin4943@gmail.com");
+        rs.next();
+
+        final Person person = entityRowMapper.mapRow(rs);
+
+        assertSoftly(softly -> {
+            softly.assertThat(person.getId()).isEqualTo(1L);
+            softly.assertThat(person.getName()).isEqualTo("min");
+            softly.assertThat(person.getAge()).isEqualTo(30);
+            softly.assertThat(person.getEmail()).isEqualTo("jongmin4943@gmail.com");
+        });
+    }
+}

--- a/src/test/java/persistence/entity/EntityRowMapperTest.java
+++ b/src/test/java/persistence/entity/EntityRowMapperTest.java
@@ -2,7 +2,6 @@ package persistence.entity;
 
 
 import domain.Person;
-import mock.MockEntityPersister;
 import org.h2.tools.SimpleResultSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,10 +17,9 @@ class EntityRowMapperTest {
     private EntityRowMapper<Person> entityRowMapper;
 
     @BeforeEach
-    void setUp() throws SQLException {
+    void setUp() {
         final Class<Person> clazz = Person.class;
-        final EntityPersister entityPersister = new MockEntityPersister(clazz);
-        entityRowMapper = new EntityRowMapper<>(clazz, entityPersister);
+        entityRowMapper = new EntityRowMapper<>(clazz);
     }
 
     @Test


### PR DESCRIPTION
저번에 피드백해주신 `EntityPersisterProvider` 의 생성의 책임에 대한 문제를 아직 명확히 해결하지 못했습니다. 마찬가지로 `EntityLoader` 를 구현했는데 일단 `EntityManager.find` 에서 계속 new 를 해서 생성하는 방식이 되었습니다.
제네릭을 쓰려다보니 미리 객체를 만들어서 Map 에 담아두려고 할때 코드가 어지러워져서 일단 이렇게 만들어 놓고 피드백 받아보려합니다! 제네릭을 안쓰려면 어디선가 강제 형변환 하는 코드가 들어가야할것같은데 어떤 방향이 나을지 고민하다가 PR 보내봅니다.

아 그리고 `EntityLoader` 에서 객체를 load 하는 메서드를 테스트하는것에 고민을 많이 했었습니다. MockJdbcTemplate 에서 queryForObject 를 override 해서 ResultSet 을 원하는 형태로 강제로 내뱉는걸 하다가 좀 아닌거같아서 포기하고 결국 일단 select 문만 테스트하고 말았습니다. 테스트가 어려워지면 형태가 안좋은 형태의 징조라는 말을 들은적이 있어서.. 어떻게 해야할까요?

이번 리뷰도 잘 부탁드립니다!

--------------------- 구조 변경 후 -------------------
DM 으로 여쭤보고 추가 Push 했습니다!
Provider 생성의 책임을 상위 객체에서 해서 EntityManager에게 주입하는 형식으로 바꿔보았습니다.
기존에 Connection Resource 관리를 신경써서 EntityManager 에게 책임을 줬었는데 그 구조가 오히려 복잡하게 만드는것같아서 뺐습니다.
일단 좀 비효율적이더라도 각 쿼리 실행하는곳에서 Connection 에 대한 관리를 맡기고, 그에따른 JdbcTemplate 을 그때마다 생성해서 사용하게 했습니다. 나중에 이 Jdbc 와 Connection 을 다루는 상위 객체가 하나 더 나와야 한다고 느끼고 있습니다.

여전히 `EntityLoader.loadById` 의 단위테스트는 어떻게 해야할지 모르겠어서 일단 나뒀습니다.
쉽지 않네요 ㅎㅎ..