### PR TITLE
step 2-2) 엔터티 초기화 (EntityLoader) 리뷰 요청 드립니다!

### DIFF
--- a/src/main/java/persistence/entity/DefaultEntityManager.java
+++ b/src/main/java/persistence/entity/DefaultEntityManager.java
@@ -3,19 +3,16 @@ package persistence.entity;
 import jdbc.JdbcTemplate;
 
 public class DefaultEntityManager implements EntityManager {
-
-    private final JdbcTemplate jdbcTemplate;
     private final EntityPersister entityPersister;
     private final EntityLoader entityLoader;
 
-    private DefaultEntityManager(JdbcTemplate jdbcTemplate, EntityPersister entityPersister, EntityLoader entityLoader) {
-        this.jdbcTemplate = jdbcTemplate;
+    private DefaultEntityManager(EntityPersister entityPersister, EntityLoader entityLoader) {
         this.entityPersister = entityPersister;
         this.entityLoader = entityLoader;
     }
 
     public static DefaultEntityManager of(JdbcTemplate jdbcTemplate) {
-        return new DefaultEntityManager(jdbcTemplate, EntityPersister.of(jdbcTemplate), EntityLoader.of(jdbcTemplate));
+        return new DefaultEntityManager(EntityPersister.of(jdbcTemplate), EntityLoader.of(jdbcTemplate));
     }
 
     @Override

--- a/src/main/java/persistence/entity/DefaultEntityManager.java
+++ b/src/main/java/persistence/entity/DefaultEntityManager.java
@@ -17,7 +17,7 @@ public class DefaultEntityManager implements EntityManager {
 
     @Override
     public <T> T find(Class<T> clazz, Long id) {
-        return entityLoader.find(clazz, id);
+        return entityLoader.selectOne(clazz, id);
     }
 
     @Override

--- a/src/main/java/persistence/entity/DefaultEntityManager.java
+++ b/src/main/java/persistence/entity/DefaultEntityManager.java
@@ -1,32 +1,26 @@
 package persistence.entity;
 
-import jdbc.EntityRowMapper;
 import jdbc.JdbcTemplate;
-import persistence.sql.dialect.Dialect;
-import persistence.sql.dialect.DialectFactory;
-import persistence.sql.dialect.h2.H2Dialect;
-import persistence.sql.dml.DmlQueryGenerator;
 
 public class DefaultEntityManager implements EntityManager {
 
     private final JdbcTemplate jdbcTemplate;
     private final EntityPersister entityPersister;
+    private final EntityLoader entityLoader;
 
-    private DefaultEntityManager(JdbcTemplate jdbcTemplate, EntityPersister entityPersister) {
+    private DefaultEntityManager(JdbcTemplate jdbcTemplate, EntityPersister entityPersister, EntityLoader entityLoader) {
         this.jdbcTemplate = jdbcTemplate;
         this.entityPersister = entityPersister;
+        this.entityLoader = entityLoader;
     }
 
     public static DefaultEntityManager of(JdbcTemplate jdbcTemplate) {
-        return new DefaultEntityManager(jdbcTemplate, EntityPersister.of(jdbcTemplate));
+        return new DefaultEntityManager(jdbcTemplate, EntityPersister.of(jdbcTemplate), EntityLoader.of(jdbcTemplate));
     }
 
     @Override
     public <T> T find(Class<T> clazz, Long id) {
-        // TODO : step 2-2 에서 EntityLoader 를 통해 구현
-        DmlQueryGenerator dmlQueryGenerator = DmlQueryGenerator.of(H2Dialect.getInstance());
-        String selectByPkQuery = dmlQueryGenerator.generateSelectByPkQuery(clazz, id);
-        return jdbcTemplate.queryForObject(selectByPkQuery, new EntityRowMapper<>(clazz));
+        return entityLoader.find(clazz, id);
     }
 
     @Override

--- a/src/main/java/persistence/entity/EntityLoader.java
+++ b/src/main/java/persistence/entity/EntityLoader.java
@@ -1,0 +1,30 @@
+package persistence.entity;
+
+import jdbc.EntityRowMapper;
+import jdbc.JdbcTemplate;
+import persistence.sql.dialect.Dialect;
+import persistence.sql.dialect.DialectFactory;
+import persistence.sql.dml.DmlQueryGenerator;
+
+public class EntityLoader {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final DmlQueryGenerator dmlQueryGenerator;
+
+    private EntityLoader(JdbcTemplate jdbcTemplate, DmlQueryGenerator dmlQueryGenerator) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.dmlQueryGenerator = dmlQueryGenerator;
+    }
+
+    public static EntityLoader of(JdbcTemplate jdbcTemplate) {
+        DialectFactory dialectFactory = DialectFactory.getInstance();
+        Dialect dialect = dialectFactory.getDialect(jdbcTemplate.getDbmsName());
+        DmlQueryGenerator dmlQueryGenerator = DmlQueryGenerator.of(dialect);
+        return new EntityLoader(jdbcTemplate, dmlQueryGenerator);
+    }
+
+    public <T> T find(Class<T> clazz, Long id) {
+        String selectByPkQuery = dmlQueryGenerator.generateSelectByPkQuery(clazz, id);
+        return jdbcTemplate.queryForObject(selectByPkQuery, new EntityRowMapper<>(clazz));
+    }
+}

--- a/src/main/java/persistence/entity/EntityLoader.java
+++ b/src/main/java/persistence/entity/EntityLoader.java
@@ -23,7 +23,7 @@ public class EntityLoader {
         return new EntityLoader(jdbcTemplate, dmlQueryGenerator);
     }
 
-    public <T> T find(Class<T> clazz, Long id) {
+    public <T> T selectOne(Class<T> clazz, Long id) {
         String selectByPkQuery = dmlQueryGenerator.generateSelectByPkQuery(clazz, id);
         return jdbcTemplate.queryForObject(selectByPkQuery, new EntityRowMapper<>(clazz));
     }

--- a/src/test/java/persistence/entity/EntityLoaderTest.java
+++ b/src/test/java/persistence/entity/EntityLoaderTest.java
@@ -47,7 +47,7 @@ class EntityLoaderTest {
     void find() {
         EntityLoader entityLoader = EntityLoader.of(jdbcTemplate);
 
-        Person person = entityLoader.find(Person.class, 1L);
+        Person person = entityLoader.selectOne(Person.class, 1L);
         assertThat(person).isNull();
     }
 

--- a/src/test/java/persistence/entity/EntityLoaderTest.java
+++ b/src/test/java/persistence/entity/EntityLoaderTest.java
@@ -1,0 +1,54 @@
+package persistence.entity;
+
+import database.DatabaseServer;
+import database.H2;
+import domain.Person;
+import jdbc.JdbcTemplate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import persistence.sql.ddl.DdlQueryGenerator;
+import persistence.sql.dialect.DialectFactory;
+import persistence.sql.meta.EntityMeta;
+import persistence.sql.meta.MetaFactory;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EntityLoaderTest {
+
+    private DatabaseServer server;
+    private JdbcTemplate jdbcTemplate;
+    private DdlQueryGenerator ddlQueryGenerator;
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        server = new H2();
+        server.start();
+        jdbcTemplate = new JdbcTemplate(server.getConnection());
+
+        EntityMeta personMeta = MetaFactory.get(Person.class);
+        DialectFactory dialectFactory = DialectFactory.getInstance();
+        ddlQueryGenerator = DdlQueryGenerator.of(dialectFactory.getDialect(jdbcTemplate.getDbmsName()));
+        jdbcTemplate.execute(ddlQueryGenerator.generateCreateQuery(personMeta));
+    }
+
+    @AfterEach
+    void tearDown() {
+        EntityMeta personMeta = MetaFactory.get(Person.class);
+        jdbcTemplate.execute(ddlQueryGenerator.generateDropQuery(personMeta));
+        server.stop();
+    }
+
+    @Test
+    @DisplayName("엔티티 조회 - 저장된 식별자로 엔티티를 조회하여 인스턴스의 존재를 확인한다")
+    void find() {
+        EntityLoader entityLoader = EntityLoader.of(jdbcTemplate);
+
+        Person person = entityLoader.find(Person.class, 1L);
+        assertThat(person).isNull();
+    }
+
+}


### PR DESCRIPTION
정완님 안녕하세요!
2주차 2단계 미션 수행하여 리뷰요청 드립니다!

EntityManager 클래스에 구현되어 있던 엔티티 조회로직을 EntityLoader 클래스에 위임하였습니다.
말씀주신 바와 같이 매니저는 이제 파사드의 형태를 띄게 되었네요!
당장은 JdbcTemplate 필드를 사용할 일이 없게 되어서 일단은 의존성을 제거했습니다.

이전 리뷰에서 말씀주신 것처럼 트랜잭션을 관리하는 것은 EntityManager 의 역할이라기 보다는
이를 호출하는 애플리케이션의 흐름에서 제어되어야 한다는 데 공감합니다.

트랜잭션이 달라지면 쓰레드의 엔티티 매니저 행동이 달라져야 하지 않을까 생각했는데,
정완님 코멘트를 보고 이건 정해진 트랜잭션 흐름에 맡겨야 한다는 생각이 들었네요!

이건 그냥 제가 상상을 많이 해본 것이기는 한데...
ORM 기술의 목적이 애플리케이션(Object) 과 관계형DB (RDB) 의 패러다임 불일치를 오브젝트 관점에서
해석하려는 것으로 알고 있습니다. 이 의미는 혹시 애플리케이션이 다중 데이터베이스를 사용할 때 객체관점에서는 데이터베이스에
종속되지 않을 수 있도록 이런 통합작업을 엔티티 매니저가 해줄 수 있지 않을까 라는 생각을 해보았네요😅

엔티티 매니저에서 JdbcTemplate 을 제거하면서 뭔가 DB 커넥션과 관련된 역할은 무엇이 있을까
생각해내 보려고 하다보니 이런 생각까지 하게 되었습니다ㅎㅎ

미션수행이 잘 되었는지 모르겠네요😆 여유있으실 때 한 번 봐주시면 감사하겠습니다~!