### PR TITLE
[2주차 - Step 4] EntityEntry PR 입니다. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,14 @@ public class CustomJpaRepository<T, ID> {
 
 - [x] 엔티티 save 가 일어날때마다 엔티티가 변경되었는지 검사한다.
 - [x] 변경이 감지되면 update 한다.
+
+### 4단계 - EntityEntry
+`EntityEntry 클래스는 엔터티의 영속성 상태와 상태 변화, 생명주기와 변경감지에 중요한 역할`
+- 요구사항 1 - CRUD 작업 수행 시 엔터티의 상태를 추가해보자
+```java
+entityEntry.updateStatus(Status status);
+```
+
+- [ ] 객체를 insert 할 시 Saving, insert 완료시 Managed 상태가 된다.
+- [ ] 객체를 select 할 시 Loading, select 완료시 Managed 상태가 된다.
+- [ ] 객체를 delete 할 시 Deleted 상태가 된다.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,6 @@ public class CustomJpaRepository<T, ID> {
 entityEntry.updateStatus(Status status);
 ```
 
-- [ ] 객체를 insert 할 시 Saving, insert 완료시 Managed 상태가 된다.
-- [ ] 객체를 select 할 시 Loading, select 완료시 Managed 상태가 된다.
-- [ ] 객체를 delete 할 시 Deleted 상태가 된다.
+- [x] 객체를 insert 할 시 Saving (?), insert 완료시 Managed 상태가 된다.
+- [x] 객체를 select 할 시 Loading, select 완료시 Managed 상태가 된다.
+- [x] 객체를 delete 할 시 Deleted 상태가 된다.

--- a/src/main/java/persistence/Application.java
+++ b/src/main/java/persistence/Application.java
@@ -5,7 +5,9 @@ import database.H2;
 import jdbc.JdbcTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import persistence.entity.EntityScanBase;
 
+@EntityScanBase(packageNames = "domain")
 public class Application {
     private static final Logger logger = LoggerFactory.getLogger(Application.class);
 

--- a/src/main/java/persistence/entity/EntityCache.java
+++ b/src/main/java/persistence/entity/EntityCache.java
@@ -1,0 +1,30 @@
+package persistence.entity;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class EntityCache {
+    private final Map<EntityKey, Object> entities;
+
+    public EntityCache() {
+        entities = new HashMap<>();
+    }
+
+    public Optional<Object> get(final EntityKey key) {
+        return Optional.ofNullable(entities.get(key));
+    }
+
+    public void add(final EntityKey key, final Object entity) {
+        entities.put(key, entity);
+    }
+
+    public void remove(final EntityKey key) {
+        entities.remove(key);
+    }
+
+    public boolean containsKey(final EntityKey key) {
+        return entities.containsKey(key);
+    }
+
+}

--- a/src/main/java/persistence/entity/EntityEntries.java
+++ b/src/main/java/persistence/entity/EntityEntries.java
@@ -1,5 +1,7 @@
 package persistence.entity;
 
+import persistence.exception.PersistenceException;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -17,5 +19,11 @@ public class EntityEntries {
 
     public Optional<EntityEntry> getEntityEntry(final EntityKey key) {
         return Optional.ofNullable(entityEntries.get(key));
+    }
+
+    public void updateEntityEntryStatus(final EntityKey entityKey, final Status status) {
+        final EntityEntry entityEntry = getEntityEntry(entityKey)
+                .orElseThrow(() -> new PersistenceException("EntityEntry 로 관리되고 있지 않은 Entity 입니다."));
+        entityEntry.updateStatus(status);
     }
 }

--- a/src/main/java/persistence/entity/EntityEntries.java
+++ b/src/main/java/persistence/entity/EntityEntries.java
@@ -1,0 +1,21 @@
+package persistence.entity;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class EntityEntries {
+    private final Map<EntityKey, EntityEntry> entityEntries;
+
+    public EntityEntries() {
+        this.entityEntries = new HashMap<>();
+    }
+
+    public void addEntityEntry(final EntityKey key, final Status status) {
+        entityEntries.put(key, new EntityEntry(key, status));
+    }
+
+    public Optional<EntityEntry> getEntityEntry(final EntityKey key) {
+        return Optional.ofNullable(entityEntries.get(key));
+    }
+}

--- a/src/main/java/persistence/entity/EntityEntries.java
+++ b/src/main/java/persistence/entity/EntityEntries.java
@@ -14,7 +14,7 @@ public class EntityEntries {
     }
 
     public void addEntityEntry(final Object entity, final Status status) {
-        entityEntries.put(entity, new EntityEntry(entity, status));
+        entityEntries.put(entity, new EntityEntry(status));
     }
 
     public Optional<EntityEntry> getEntityEntry(final Object entity) {

--- a/src/main/java/persistence/entity/EntityEntries.java
+++ b/src/main/java/persistence/entity/EntityEntries.java
@@ -2,27 +2,27 @@ package persistence.entity;
 
 import persistence.exception.PersistenceException;
 
-import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Optional;
 
 public class EntityEntries {
-    private final Map<EntityKey, EntityEntry> entityEntries;
+    private final Map<Object, EntityEntry> entityEntries;
 
     public EntityEntries() {
-        this.entityEntries = new HashMap<>();
+        this.entityEntries = new IdentityHashMap<>();
     }
 
-    public void addEntityEntry(final EntityKey key, final Status status) {
-        entityEntries.put(key, new EntityEntry(key, status));
+    public void addEntityEntry(final Object entity, final Status status) {
+        entityEntries.put(entity, new EntityEntry(entity, status));
     }
 
-    public Optional<EntityEntry> getEntityEntry(final EntityKey key) {
-        return Optional.ofNullable(entityEntries.get(key));
+    public Optional<EntityEntry> getEntityEntry(final Object entity) {
+        return Optional.ofNullable(entityEntries.get(entity));
     }
 
-    public void updateEntityEntryStatus(final EntityKey entityKey, final Status status) {
-        final EntityEntry entityEntry = getEntityEntry(entityKey)
+    public void updateEntityEntryStatus(final Object entity, final Status status) {
+        final EntityEntry entityEntry = getEntityEntry(entity)
                 .orElseThrow(() -> new PersistenceException("EntityEntry 로 관리되고 있지 않은 Entity 입니다."));
         entityEntry.updateStatus(status);
     }

--- a/src/main/java/persistence/entity/EntityEntry.java
+++ b/src/main/java/persistence/entity/EntityEntry.java
@@ -4,12 +4,10 @@ import java.util.Objects;
 
 public class EntityEntry {
 
-    private final Object entity;
     private Status status;
 
 
-    public EntityEntry(final Object entity, final Status status) {
-        this.entity = entity;
+    public EntityEntry(final Status status) {
         this.status = status;
     }
 
@@ -26,11 +24,11 @@ public class EntityEntry {
         if (this == object) return true;
         if (object == null || getClass() != object.getClass()) return false;
         final EntityEntry that = (EntityEntry) object;
-        return Objects.equals(entity, that.entity) && status == that.status;
+        return status == that.status;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(entity, status);
+        return Objects.hash(status);
     }
 }

--- a/src/main/java/persistence/entity/EntityEntry.java
+++ b/src/main/java/persistence/entity/EntityEntry.java
@@ -4,12 +4,12 @@ import java.util.Objects;
 
 public class EntityEntry {
 
-    private final EntityKey entityKey;
+    private final Object entity;
     private Status status;
 
 
-    public EntityEntry(final EntityKey entityKey, final Status status) {
-        this.entityKey = entityKey;
+    public EntityEntry(final Object entity, final Status status) {
+        this.entity = entity;
         this.status = status;
     }
 
@@ -26,11 +26,11 @@ public class EntityEntry {
         if (this == object) return true;
         if (object == null || getClass() != object.getClass()) return false;
         final EntityEntry that = (EntityEntry) object;
-        return Objects.equals(entityKey, that.entityKey) && status == that.status;
+        return Objects.equals(entity, that.entity) && status == that.status;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(entityKey, status);
+        return Objects.hash(entity, status);
     }
 }

--- a/src/main/java/persistence/entity/EntityEntry.java
+++ b/src/main/java/persistence/entity/EntityEntry.java
@@ -1,0 +1,36 @@
+package persistence.entity;
+
+import java.util.Objects;
+
+public class EntityEntry {
+
+    private final EntityKey entityKey;
+    private Status status;
+
+
+    public EntityEntry(final EntityKey entityKey, final Status status) {
+        this.entityKey = entityKey;
+        this.status = status;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void updateStatus(final Status status) {
+        this.status = status;
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+        final EntityEntry that = (EntityEntry) object;
+        return Objects.equals(entityKey, that.entityKey) && status == that.status;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(entityKey, status);
+    }
+}

--- a/src/main/java/persistence/entity/EntityLoaderProvider.java
+++ b/src/main/java/persistence/entity/EntityLoaderProvider.java
@@ -1,28 +1,18 @@
 package persistence.entity;
 
-import jdbc.JdbcTemplate;
-import persistence.sql.dml.DmlGenerator;
-
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class EntityLoaderProvider {
 
     private final Map<Class<?>, EntityLoader<?>> cache;
-    private final DmlGenerator dmlGenerator;
-    private final JdbcTemplate jdbcTemplate;
 
-    public EntityLoaderProvider(final DmlGenerator dmlGenerator, final JdbcTemplate jdbcTemplate) {
-        this.dmlGenerator = dmlGenerator;
-        this.jdbcTemplate = jdbcTemplate;
-        this.cache = new ConcurrentHashMap<>();
+    public EntityLoaderProvider(final Map<Class<?>, EntityLoader<?>> loaders) {
+        this.cache = loaders;
     }
 
     @SuppressWarnings("unchecked")
     public <T> EntityLoader<T> getEntityLoader(final Class<T> clazz) {
-        return (EntityLoader<T>) cache.computeIfAbsent(clazz, cls ->
-                new EntityLoader<>(clazz, dmlGenerator, jdbcTemplate)
-        );
+        return (EntityLoader<T>) cache.get(clazz);
     }
 
 }

--- a/src/main/java/persistence/entity/EntityManagerFactory.java
+++ b/src/main/java/persistence/entity/EntityManagerFactory.java
@@ -1,0 +1,5 @@
+package persistence.entity;
+
+public interface EntityManagerFactory {
+    EntityManager createEntityManager();
+}

--- a/src/main/java/persistence/entity/EntityPersisterProvider.java
+++ b/src/main/java/persistence/entity/EntityPersisterProvider.java
@@ -1,27 +1,16 @@
 package persistence.entity;
 
-import jdbc.JdbcTemplate;
-import persistence.sql.dml.DmlGenerator;
-
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class EntityPersisterProvider {
-
     private final Map<Class<?>, EntityPersister> cache;
-    private final DmlGenerator dmlGenerator;
-    private final JdbcTemplate jdbcTemplate;
 
-    public EntityPersisterProvider(final DmlGenerator dmlGenerator, final JdbcTemplate jdbcTemplate) {
-        this.dmlGenerator = dmlGenerator;
-        this.jdbcTemplate = jdbcTemplate;
-        this.cache = new ConcurrentHashMap<>();
+    public EntityPersisterProvider(final Map<Class<?>, EntityPersister> persisters) {
+        this.cache = persisters;
     }
 
     public EntityPersister getEntityPersister(final Class<?> clazz) {
-        return cache.computeIfAbsent(clazz, cls ->
-                new EntityPersister(clazz, dmlGenerator, jdbcTemplate)
-        );
+        return cache.get(clazz);
     }
 
 }

--- a/src/main/java/persistence/entity/EntityScanBase.java
+++ b/src/main/java/persistence/entity/EntityScanBase.java
@@ -1,0 +1,14 @@
+package persistence.entity;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface EntityScanBase {
+
+    String[] packageNames();
+
+}

--- a/src/main/java/persistence/entity/EntityScanner.java
+++ b/src/main/java/persistence/entity/EntityScanner.java
@@ -1,0 +1,146 @@
+package persistence.entity;
+
+import jakarta.persistence.Entity;
+import persistence.exception.PersistenceException;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.*;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class EntityScanner {
+    private static final char DOT = '.';
+    private static final char FILE_SEPARATOR = '/';
+    private static final String FILE = "file";
+    private static final String JAR = "jar";
+    private static final String CLASS_FILE_EXTENSION = ".class";
+    private final List<Class<?>> entityClasses;
+
+    public EntityScanner(final Class<?> baseClass) {
+        this.entityClasses = scan(baseClass);
+    }
+
+    public List<Class<?>> getEntityClasses() {
+        return this.entityClasses;
+    }
+
+    private List<Class<?>> scan(final Class<?> baseClass) {
+        if (baseClass.isAnnotationPresent(EntityScanBase.class)) {
+            final EntityScanBase annotation = baseClass.getAnnotation(EntityScanBase.class);
+            final String[] packageNames = annotation.packageNames();
+            return scanPackages(packageNames);
+        }
+
+        return scanPackages(baseClass.getPackage().getName());
+    }
+
+    private List<Class<?>> scanPackages(final String... packagePaths) {
+        return Arrays.stream(packagePaths)
+                .map(packageName -> scanPackage(getPackageFullPath(packageName), packageName))
+                .flatMap(List::stream)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    private Path getPackageFullPath(final String packageName) {
+        try {
+            final String packageRelativePath = getFilePath(packageName);
+            final URI packageUri = getPackageUri(packageRelativePath);
+            if (isSchemeFile(packageUri)) {
+                return Paths.get(packageUri);
+            } else if (isSchemeJar(packageUri)) {
+                return getPathInJar(packageUri, packageRelativePath);
+            }
+        } catch (final URISyntaxException | IOException e) {
+            throw new PersistenceException("packageFullPath 를 가져오는것에 실패했습니다", e);
+        }
+        throw new PersistenceException("packageFullPath 를 가져오는것에 실패했습니다");
+    }
+
+    private static Path getPathInJar(final URI packageUri, final String packageRelativePath) throws IOException {
+        final FileSystem fileSystem = FileSystems.newFileSystem(packageUri, Collections.emptyMap());
+        final Path packageFullPathInJar = fileSystem.getPath(packageRelativePath);
+        fileSystem.close();
+        return packageFullPathInJar;
+    }
+
+    private String getFilePath(final String packageName) {
+        return packageName.replace(DOT, FILE_SEPARATOR);
+    }
+
+    private URI getPackageUri(final String packageRelativePath) throws URISyntaxException {
+        final URL resource = Thread.currentThread().getContextClassLoader().getResource(packageRelativePath);
+        if (Objects.isNull(resource)) {
+            throw new PersistenceException("Entity Scan 중 resource 가져오기에 실패했습니다.");
+        }
+        return resource.toURI();
+    }
+
+    private boolean isSchemeJar(final URI packageUri) {
+        return JAR.equals(packageUri.getScheme());
+    }
+
+    private boolean isSchemeFile(final URI packageUri) {
+        return FILE.equals(packageUri.getScheme());
+    }
+
+    private List<Class<?>> scanPackage(final Path packagePath, final String packageName) {
+        if (!Files.exists(packagePath)) {
+            return Collections.emptyList();
+        }
+
+        final Map<Boolean, List<Path>> partitionedFiles = partitionRegularFiles(packagePath);
+        final List<Path> regularFiles = partitionedFiles.get(true);
+        final List<Path> nonFiles = partitionedFiles.get(false);
+
+        final List<Class<?>> entityClasses = getEntityClasses(packageName, regularFiles);
+        final List<Class<?>> nestedClasses = getNestedEntityClasses(packageName, nonFiles);
+        entityClasses.addAll(nestedClasses);
+        return entityClasses;
+    }
+
+    private Map<Boolean, List<Path>> partitionRegularFiles(final Path packagePath) {
+        try (final Stream<Path> list = Files.list(packagePath)) {
+            return list.collect(Collectors.partitioningBy(Files::isRegularFile));
+        } catch (final IOException e) {
+            throw new PersistenceException("파일을 분리하는 도중 에러가 발생했습니다.", e);
+        }
+    }
+
+    private List<Class<?>> getNestedEntityClasses(final String packageName, final List<Path> nonFiles) {
+        return nonFiles.stream()
+                .filter(Files::isDirectory)
+                .map(path -> scanPackage(path, packageName + DOT + path.getFileName()))
+                .flatMap(List::stream)
+                .filter(clazz -> clazz.isAnnotationPresent(Entity.class))
+                .collect(Collectors.toList());
+    }
+
+    private List<Class<?>> getEntityClasses(final String packageName, final List<Path> regularFiles) {
+        return regularFiles.stream()
+                .map(Path::getFileName)
+                .map(Path::toString)
+                .filter(this::isClassFile)
+                .map(fileName -> createClassBy(packageName, fileName))
+                .filter(clazz -> clazz.isAnnotationPresent(Entity.class))
+                .collect(Collectors.toList());
+    }
+
+    private boolean isClassFile(final String fileName) {
+        return fileName.endsWith(CLASS_FILE_EXTENSION);
+    }
+
+    private Class<?> createClassBy(final String packageName, final String fileName) {
+        final String classFullName = packageName + DOT + fileName.replaceFirst("\\.class$", "");
+        try {
+            return Class.forName(classFullName);
+        } catch (final ClassNotFoundException e) {
+            throw new PersistenceException(classFullName + " 클래스를 찾을 수 없습니다.", e);
+        }
+    }
+
+
+}

--- a/src/main/java/persistence/entity/EntitySnapshots.java
+++ b/src/main/java/persistence/entity/EntitySnapshots.java
@@ -1,0 +1,18 @@
+package persistence.entity;
+
+import persistence.util.ReflectionUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class EntitySnapshots {
+    private final Map<EntityKey, Object> entitySnapshots;
+
+    public EntitySnapshots() {
+        entitySnapshots = new HashMap<>();
+    }
+
+    public Object getDatabaseSnapshot(final EntityKey key, final Object entity) {
+        return entitySnapshots.computeIfAbsent(key, entityKey -> ReflectionUtils.shallowCopy(entity));
+    }
+}

--- a/src/main/java/persistence/entity/PersistenceContext.java
+++ b/src/main/java/persistence/entity/PersistenceContext.java
@@ -13,9 +13,9 @@ public interface PersistenceContext {
 
     Object getDatabaseSnapshot(EntityKey key, Object entity);
 
-    void addEntityEntry(EntityKey key, Status status);
+    void addEntityEntry(Object entity, Status status);
 
-    Optional<EntityEntry> getEntityEntry(EntityKey key);
+    Optional<EntityEntry> getEntityEntry(Object entity);
 
-    void updateEntityEntryStatus(EntityKey entityKey, Status status);
+    void updateEntityEntryStatus(Object entity, Status status);
 }

--- a/src/main/java/persistence/entity/PersistenceContext.java
+++ b/src/main/java/persistence/entity/PersistenceContext.java
@@ -13,5 +13,4 @@ public interface PersistenceContext {
 
     Object getDatabaseSnapshot(EntityKey key, Object entity);
 
-    Object getCachedDatabaseSnapshot(EntityKey key);
 }

--- a/src/main/java/persistence/entity/PersistenceContext.java
+++ b/src/main/java/persistence/entity/PersistenceContext.java
@@ -13,4 +13,9 @@ public interface PersistenceContext {
 
     Object getDatabaseSnapshot(EntityKey key, Object entity);
 
+    void addEntityEntry(EntityKey key, Status status);
+
+    Optional<EntityEntry> getEntityEntry(EntityKey key);
+
+    void updateEntityEntryStatus(EntityKey entityKey, Status status);
 }

--- a/src/main/java/persistence/entity/SimpleEntityManager.java
+++ b/src/main/java/persistence/entity/SimpleEntityManager.java
@@ -107,11 +107,12 @@ public class SimpleEntityManager implements EntityManager {
     private boolean isDirty(final Object entity) {
         final EntityPersister entityPersister = entityPersisterProvider.getEntityPersister(entity.getClass());
         final Object idValue = extractId(entity, entityPersister);
-        final Object cachedDatabaseSnapshot = persistenceContext.getCachedDatabaseSnapshot(entityKeyGenerator.generate(entity.getClass(), idValue));
+        final EntityKey entityKey = entityKeyGenerator.generate(entity.getClass(), idValue);
+        final Object databaseSnapshot = persistenceContext.getDatabaseSnapshot(entityKey, entity);
 
         return entityPersister.getColumnFieldNames()
                 .stream()
-                .anyMatch(columnName -> hasDifferentValue(entity, cachedDatabaseSnapshot, columnName));
+                .anyMatch(columnName -> hasDifferentValue(entity, databaseSnapshot, columnName));
     }
 
     private boolean hasDifferentValue(final Object entity, final Object cachedDatabaseSnapshot, final String columnName) {

--- a/src/main/java/persistence/entity/SimpleEntityManagerFactory.java
+++ b/src/main/java/persistence/entity/SimpleEntityManagerFactory.java
@@ -1,0 +1,49 @@
+package persistence.entity;
+
+import jdbc.JdbcTemplate;
+import persistence.core.PersistenceEnvironment;
+import persistence.sql.dml.DmlGenerator;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class SimpleEntityManagerFactory implements EntityManagerFactory {
+    private final EntityPersisterProvider entityPersisterProvider;
+    private final EntityLoaderProvider entityLoaderProvider;
+
+    public SimpleEntityManagerFactory(final EntityScanner entityScanner, final PersistenceEnvironment persistenceEnvironment) {
+        final List<Class<?>> entityClasses = entityScanner.getEntityClasses();
+        final DmlGenerator dmlGenerator = persistenceEnvironment.getDmlGenerator();
+        final JdbcTemplate jdbcTemplate = new JdbcTemplate(persistenceEnvironment.getConnection());
+
+        final Map<Class<?>, EntityPersister> persisters = createEntityPersisters(entityClasses, dmlGenerator, jdbcTemplate);
+        final Map<Class<?>, EntityLoader<?>> loaders = createEntityLoaders(entityClasses, dmlGenerator, jdbcTemplate);
+
+        this.entityPersisterProvider = new EntityPersisterProvider(persisters);
+        this.entityLoaderProvider = new EntityLoaderProvider(loaders);
+    }
+
+    private Map<Class<?>, EntityPersister> createEntityPersisters(final List<Class<?>> entityClasses, final DmlGenerator dmlGenerator, final JdbcTemplate jdbcTemplate) {
+        return entityClasses.stream()
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        clazz -> new EntityPersister(clazz, dmlGenerator, jdbcTemplate)
+                ));
+    }
+
+    private Map<Class<?>, EntityLoader<?>> createEntityLoaders(final List<Class<?>> entityClasses, final DmlGenerator dmlGenerator, final JdbcTemplate jdbcTemplate) {
+        return entityClasses.stream()
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        clazz -> new EntityLoader<>(clazz, dmlGenerator, jdbcTemplate)
+                ));
+    }
+
+    @Override
+    public EntityManager createEntityManager() {
+        return new SimpleEntityManager(this.entityPersisterProvider, this.entityLoaderProvider);
+    }
+}
+

--- a/src/main/java/persistence/entity/SimplePersistenceContext.java
+++ b/src/main/java/persistence/entity/SimplePersistenceContext.java
@@ -1,7 +1,6 @@
 package persistence.entity;
 
 import persistence.exception.PersistenceException;
-import persistence.util.ReflectionUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -10,12 +9,12 @@ import java.util.Optional;
 public class SimplePersistenceContext implements PersistenceContext {
 
     private final Map<EntityKey, Object> entities;
-    private final Map<EntityKey, Object> entitySnapshots;
+    private final EntitySnapshots entitySnapshots;
     private final EntityEntries entityEntries;
 
     public SimplePersistenceContext() {
         this.entities = new HashMap<>();
-        this.entitySnapshots = new HashMap<>();
+        this.entitySnapshots = new EntitySnapshots();
         this.entityEntries = new EntityEntries();
     }
 
@@ -41,7 +40,7 @@ public class SimplePersistenceContext implements PersistenceContext {
 
     @Override
     public Object getDatabaseSnapshot(final EntityKey key, final Object entity) {
-        return entitySnapshots.computeIfAbsent(key, entityKey -> ReflectionUtils.shallowCopy(entity));
+        return entitySnapshots.getDatabaseSnapshot(key, entity);
     }
 
     @Override

--- a/src/main/java/persistence/entity/SimplePersistenceContext.java
+++ b/src/main/java/persistence/entity/SimplePersistenceContext.java
@@ -2,30 +2,28 @@ package persistence.entity;
 
 import persistence.exception.PersistenceException;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
 public class SimplePersistenceContext implements PersistenceContext {
 
-    private final Map<EntityKey, Object> entities;
+    private final EntityCache entities;
     private final EntitySnapshots entitySnapshots;
     private final EntityEntries entityEntries;
 
     public SimplePersistenceContext() {
-        this.entities = new HashMap<>();
+        this.entities = new EntityCache();
         this.entitySnapshots = new EntitySnapshots();
         this.entityEntries = new EntityEntries();
     }
 
     @Override
     public Optional<Object> getEntity(final EntityKey key) {
-        return Optional.ofNullable(entities.get(key));
+        return entities.get(key);
     }
 
     @Override
     public void addEntity(final EntityKey key, final Object entity) {
-        entities.put(key, entity);
+        entities.add(key, entity);
     }
 
     @Override

--- a/src/main/java/persistence/entity/SimplePersistenceContext.java
+++ b/src/main/java/persistence/entity/SimplePersistenceContext.java
@@ -22,6 +22,7 @@ public class SimplePersistenceContext implements PersistenceContext {
     @Override
     public void addEntity(final EntityKey key, final Object entity) {
         entities.add(key, entity);
+        updateEntityEntryStatus(entity, Status.MANAGED);
     }
 
     @Override

--- a/src/main/java/persistence/entity/SimplePersistenceContext.java
+++ b/src/main/java/persistence/entity/SimplePersistenceContext.java
@@ -1,5 +1,6 @@
 package persistence.entity;
 
+import persistence.exception.PersistenceException;
 import persistence.util.ReflectionUtils;
 
 import java.util.HashMap;
@@ -10,10 +11,12 @@ public class SimplePersistenceContext implements PersistenceContext {
 
     private final Map<EntityKey, Object> entities;
     private final Map<EntityKey, Object> entitySnapshots;
+    private final Map<EntityKey, EntityEntry> entityEntries;
 
     public SimplePersistenceContext() {
         this.entities = new HashMap<>();
         this.entitySnapshots = new HashMap<>();
+        this.entityEntries = new HashMap<>();
     }
 
     @Override
@@ -41,4 +44,20 @@ public class SimplePersistenceContext implements PersistenceContext {
         return entitySnapshots.computeIfAbsent(key, entityKey -> ReflectionUtils.shallowCopy(entity));
     }
 
+    @Override
+    public void addEntityEntry(final EntityKey key, final Status status) {
+        entityEntries.put(key, new EntityEntry(key, status));
+    }
+
+    @Override
+    public Optional<EntityEntry> getEntityEntry(final EntityKey key) {
+        return Optional.ofNullable(entityEntries.get(key));
+    }
+
+    @Override
+    public void updateEntityEntryStatus(final EntityKey entityKey, final Status status) {
+        final EntityEntry entityEntry = getEntityEntry(entityKey)
+                .orElseThrow(() -> new PersistenceException("PersistenceContext 내에 관리되고 있지 않은 Entity 입니다."));
+        entityEntry.updateStatus(status);
+    }
 }

--- a/src/main/java/persistence/entity/SimplePersistenceContext.java
+++ b/src/main/java/persistence/entity/SimplePersistenceContext.java
@@ -40,17 +40,17 @@ public class SimplePersistenceContext implements PersistenceContext {
     }
 
     @Override
-    public void addEntityEntry(final EntityKey key, final Status status) {
-        entityEntries.addEntityEntry(key, status);
+    public void addEntityEntry(final Object entity, final Status status) {
+        entityEntries.addEntityEntry(entity, status);
     }
 
     @Override
-    public Optional<EntityEntry> getEntityEntry(final EntityKey key) {
-        return entityEntries.getEntityEntry(key);
+    public Optional<EntityEntry> getEntityEntry(final Object entity) {
+        return entityEntries.getEntityEntry(entity);
     }
 
     @Override
-    public void updateEntityEntryStatus(final EntityKey entityKey, final Status status) {
-        entityEntries.updateEntityEntryStatus(entityKey, status);
+    public void updateEntityEntryStatus(final Object entity, final Status status) {
+        entityEntries.updateEntityEntryStatus(entity, status);
     }
 }

--- a/src/main/java/persistence/entity/SimplePersistenceContext.java
+++ b/src/main/java/persistence/entity/SimplePersistenceContext.java
@@ -41,10 +41,4 @@ public class SimplePersistenceContext implements PersistenceContext {
         return entitySnapshots.computeIfAbsent(key, entityKey -> ReflectionUtils.shallowCopy(entity));
     }
 
-    @Override
-    public Object getCachedDatabaseSnapshot(final EntityKey key) {
-        return entitySnapshots.get(key);
-    }
-
-
 }

--- a/src/main/java/persistence/entity/SimplePersistenceContext.java
+++ b/src/main/java/persistence/entity/SimplePersistenceContext.java
@@ -1,7 +1,5 @@
 package persistence.entity;
 
-import persistence.exception.PersistenceException;
-
 import java.util.Optional;
 
 public class SimplePersistenceContext implements PersistenceContext {
@@ -53,8 +51,6 @@ public class SimplePersistenceContext implements PersistenceContext {
 
     @Override
     public void updateEntityEntryStatus(final EntityKey entityKey, final Status status) {
-        final EntityEntry entityEntry = getEntityEntry(entityKey)
-                .orElseThrow(() -> new PersistenceException("PersistenceContext 내에 관리되고 있지 않은 Entity 입니다."));
-        entityEntry.updateStatus(status);
+        entityEntries.updateEntityEntryStatus(entityKey, status);
     }
 }

--- a/src/main/java/persistence/entity/SimplePersistenceContext.java
+++ b/src/main/java/persistence/entity/SimplePersistenceContext.java
@@ -11,12 +11,12 @@ public class SimplePersistenceContext implements PersistenceContext {
 
     private final Map<EntityKey, Object> entities;
     private final Map<EntityKey, Object> entitySnapshots;
-    private final Map<EntityKey, EntityEntry> entityEntries;
+    private final EntityEntries entityEntries;
 
     public SimplePersistenceContext() {
         this.entities = new HashMap<>();
         this.entitySnapshots = new HashMap<>();
-        this.entityEntries = new HashMap<>();
+        this.entityEntries = new EntityEntries();
     }
 
     @Override
@@ -46,12 +46,12 @@ public class SimplePersistenceContext implements PersistenceContext {
 
     @Override
     public void addEntityEntry(final EntityKey key, final Status status) {
-        entityEntries.put(key, new EntityEntry(key, status));
+        entityEntries.addEntityEntry(key, status);
     }
 
     @Override
     public Optional<EntityEntry> getEntityEntry(final EntityKey key) {
-        return Optional.ofNullable(entityEntries.get(key));
+        return entityEntries.getEntityEntry(key);
     }
 
     @Override

--- a/src/main/java/persistence/entity/Status.java
+++ b/src/main/java/persistence/entity/Status.java
@@ -1,0 +1,10 @@
+package persistence.entity;
+
+public enum Status {
+    MANAGED,
+    READ_ONLY,
+    DELETED,
+    GONE,
+    LOADING,
+    SAVING
+}

--- a/src/test/java/domain/FixtureEntity.java
+++ b/src/test/java/domain/FixtureEntity.java
@@ -126,5 +126,39 @@ public class FixtureEntity {
         @Transient
         private Integer index;
 
+        protected Person() {
+        }
+
+        public Person(final Long id, final String name, final Integer age, final String email) {
+            this.id = id;
+            this.name = name;
+            this.age = age;
+            this.email = email;
+        }
+
+        public Person(final String name, final Integer age, final String email) {
+            this(null, name, age, email);
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Integer getAge() {
+            return age;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        public void changeEmail(final String email) {
+            this.email = email;
+        }
+
     }
 }

--- a/src/test/java/mock/MockDatabaseServer.java
+++ b/src/test/java/mock/MockDatabaseServer.java
@@ -19,7 +19,7 @@ public class MockDatabaseServer implements DatabaseServer {
     }
 
     @Override
-    public Connection getConnection() throws SQLException {
+    public Connection getConnection() {
         return null;
     }
 }

--- a/src/test/java/mock/MockJdbcTemplate.java
+++ b/src/test/java/mock/MockJdbcTemplate.java
@@ -2,11 +2,9 @@ package mock;
 
 import jdbc.JdbcTemplate;
 
-import java.sql.SQLException;
-
 public class MockJdbcTemplate extends JdbcTemplate {
 
-    public MockJdbcTemplate() throws SQLException {
+    public MockJdbcTemplate(){
         super(new MockDatabaseServer().getConnection());
     }
 }

--- a/src/test/java/persistence/ApplicationTest.java
+++ b/src/test/java/persistence/ApplicationTest.java
@@ -1,6 +1,7 @@
 package persistence;
 
 import domain.Person;
+import jdbc.RowMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -28,6 +29,10 @@ class ApplicationTest extends IntegrationTestEnvironment {
         final Person result = jdbcTemplate.queryForObject(query, personRowMapper());
 
         assertThat(result).isNotNull();
+    }
+
+    private RowMapper<Person> personRowMapper() {
+        return rs -> new Person(rs.getLong("id"), rs.getString("nick_name"), rs.getInt("old"), rs.getString("email"));
     }
 
 }

--- a/src/test/java/persistence/IntegrationTestEnvironment.java
+++ b/src/test/java/persistence/IntegrationTestEnvironment.java
@@ -4,7 +4,6 @@ import database.DatabaseServer;
 import database.H2;
 import domain.Person;
 import jdbc.JdbcTemplate;
-import jdbc.RowMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import persistence.core.EntityMetadata;
@@ -24,6 +23,7 @@ public abstract class IntegrationTestEnvironment {
     protected DmlGenerator dmlGenerator;
     protected EntityMetadata<?> entityMetadata;
     protected JdbcTemplate jdbcTemplate;
+    protected PersistenceEnvironment persistenceEnvironment;
     protected List<Person> people;
 
     @BeforeEach
@@ -31,7 +31,7 @@ public abstract class IntegrationTestEnvironment {
         server = new H2();
         server.start();
         jdbcTemplate = new JdbcTemplate(server.getConnection());
-        final PersistenceEnvironment persistenceEnvironment = new PersistenceEnvironment(server, new H2Dialect());
+        persistenceEnvironment = new PersistenceEnvironment(server, new H2Dialect());
         ddlGenerator = new DdlGenerator(persistenceEnvironment.getDialect());
         dmlGenerator = new DmlGenerator(persistenceEnvironment.getDialect());
 
@@ -62,7 +62,4 @@ public abstract class IntegrationTestEnvironment {
         return List.of(test00, test01, test02, test03);
     }
 
-    protected RowMapper<Person> personRowMapper() {
-        return rs -> new Person(rs.getLong("id"), rs.getString("nick_name"), rs.getInt("old"), rs.getString("email"));
-    }
 }

--- a/src/test/java/persistence/entity/CustomJpaRepositoryTest.java
+++ b/src/test/java/persistence/entity/CustomJpaRepositoryTest.java
@@ -1,9 +1,11 @@
 package persistence.entity;
 
-import domain.Person;
+import domain.FixtureEntity.Person;
+import jdbc.RowMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import persistence.Application;
 import persistence.IntegrationTestEnvironment;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -14,9 +16,8 @@ class CustomJpaRepositoryTest extends IntegrationTestEnvironment {
 
     @BeforeEach
     void setup() {
-        final EntityPersisterProvider entityPersisterProvider = new EntityPersisterProvider(dmlGenerator, jdbcTemplate);
-        final EntityLoaderProvider entityLoaderProvider = new EntityLoaderProvider(dmlGenerator, jdbcTemplate);
-        final EntityManager entityManager = new SimpleEntityManager(entityPersisterProvider, entityLoaderProvider);
+        final EntityManagerFactory entityManagerFactory = new SimpleEntityManagerFactory(new EntityScanner(Application.class), persistenceEnvironment);
+        final EntityManager entityManager = entityManagerFactory.createEntityManager();
         customJpaRepository = new CustomJpaRepository<>(entityManager, Person.class);
     }
 
@@ -61,5 +62,9 @@ class CustomJpaRepositoryTest extends IntegrationTestEnvironment {
             softly.assertThat(fixture.getAge()).isEqualTo(testV2.getAge());
             softly.assertThat(fixture.getEmail()).isEqualTo(testV2.getEmail());
         });
+    }
+
+    private RowMapper<Person> personRowMapper() {
+        return rs -> new Person(rs.getLong("id"), rs.getString("nick_name"), rs.getInt("old"), rs.getString("email"));
     }
 }

--- a/src/test/java/persistence/entity/EntityCacheTest.java
+++ b/src/test/java/persistence/entity/EntityCacheTest.java
@@ -1,0 +1,70 @@
+package persistence.entity;
+
+
+import domain.FixturePerson;
+import domain.Person;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+class EntityCacheTest {
+    private EntityCache entityCache;
+    private Person fixture;
+    private EntityKey entityKey;
+
+    @BeforeEach
+    void setUp() {
+        entityCache = new EntityCache();
+        fixture = FixturePerson.create(1L);
+        entityKey = new EntityKey(Person.class, 1L);
+
+    }
+
+    @Test
+    @DisplayName("entityCache.get 를 통해 없는 Entity 조회시 Optional.empty 를 반환한다.")
+    void entityCacheNotExistTest() {
+        final Optional<Object> result = entityCache.get(entityKey);
+
+        assertThat(result).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    @DisplayName("entityCache 를 통해 Entity 들을 저장하고 조회할 수 있다.")
+    void entityCacheTest() {
+        entityCache.add(entityKey, fixture);
+
+        final Optional<Object> result = entityCache.get(entityKey);
+
+        assertThat(result).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("entityCache.remove 를 통해 저장된 Entity 를 제거할 수 있다.")
+    void entityCacheRemoveTest() {
+        entityCache.add(entityKey, fixture);
+
+        entityCache.remove(entityKey);
+
+        final Optional<Object> result = entityCache.get(entityKey);
+        assertThat(result).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    @DisplayName("entityCache.containsKey 를 통해 cache 에 해당 key 가 존재하는지 여부를 반환 받을 수 있다.")
+    void entityCacheContainsKeyTest() {
+        final EntityKey newKey = new EntityKey(Person.class, 2L);
+
+        entityCache.add(entityKey, fixture);
+
+        assertSoftly(softly->{
+            softly.assertThat(entityCache.containsKey(entityKey)).isTrue();
+            softly.assertThat(entityCache.containsKey(newKey)).isFalse();
+        });
+    }
+
+}

--- a/src/test/java/persistence/entity/EntityEntriesTest.java
+++ b/src/test/java/persistence/entity/EntityEntriesTest.java
@@ -29,8 +29,7 @@ class EntityEntriesTest {
 
         assertSoftly(softly -> {
             softly.assertThat(result).isNotEmpty();
-            final EntityEntry entityEntry = result.get();
-            softly.assertThat(entityEntry.getStatus()).isEqualTo(Status.LOADING);
+            softly.assertThat(result.get().getStatus()).isEqualTo(Status.LOADING);
         });
     }
 
@@ -41,5 +40,21 @@ class EntityEntriesTest {
 
         assertThat(result).isEqualTo(Optional.empty());
     }
+
+    @Test
+    @DisplayName("updateEntityEntryStatus 를 통해 해당 key 의 EntityEntry 의 상태를 변경할 수 있다.")
+    void updateEntityEntryStatusTest() {
+        entityEntries.addEntityEntry(entityKey, Status.LOADING);
+
+        entityEntries.updateEntityEntryStatus(entityKey, Status.MANAGED);
+
+        final Optional<EntityEntry> result = entityEntries.getEntityEntry(entityKey);
+
+        assertSoftly(softly -> {
+            softly.assertThat(result).isNotEmpty();
+            softly.assertThat(result.get().getStatus()).isEqualTo(Status.MANAGED);
+        });
+    }
+
 
 }

--- a/src/test/java/persistence/entity/EntityEntriesTest.java
+++ b/src/test/java/persistence/entity/EntityEntriesTest.java
@@ -1,31 +1,34 @@
 package persistence.entity;
 
+import domain.FixturePerson;
 import domain.Person;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import persistence.exception.PersistenceException;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class EntityEntriesTest {
     private EntityEntries entityEntries;
-    private EntityKey entityKey;
+    private Person person;
 
     @BeforeEach
     void setUp() {
         entityEntries = new EntityEntries();
-        entityKey = new EntityKey(Person.class, 1L);
+        person = FixturePerson.create(null);
     }
 
     @Test
-    @DisplayName("EntityEntries 를 통해 EntityEntry 들를 저장하고 조회할 수 있다.")
+    @DisplayName("EntityEntries 를 통해 EntityEntry 들을 person instance 를 이용해 저장하고 조회할 수 있다.")
     void entityEntriesTest() {
-        entityEntries.addEntityEntry(entityKey, Status.LOADING);
+        entityEntries.addEntityEntry(person, Status.LOADING);
 
-        final Optional<EntityEntry> result = entityEntries.getEntityEntry(entityKey);
+        final Optional<EntityEntry> result = entityEntries.getEntityEntry(person);
 
         assertSoftly(softly -> {
             softly.assertThat(result).isNotEmpty();
@@ -34,21 +37,21 @@ class EntityEntriesTest {
     }
 
     @Test
-    @DisplayName("EntityEntries 를 통해 없는 key 조회시 Optional.empty 가 반환된다.")
+    @DisplayName("EntityEntries 를 통해 없는 person instance 조회시 Optional.empty 가 반환된다.")
     void getEntityEntryNotExistTest() {
-        final Optional<EntityEntry> result = entityEntries.getEntityEntry(entityKey);
+        final Person newPerson = FixturePerson.create(null);
+        final Optional<EntityEntry> result = entityEntries.getEntityEntry(newPerson);
 
         assertThat(result).isEqualTo(Optional.empty());
     }
 
     @Test
-    @DisplayName("updateEntityEntryStatus 를 통해 해당 key 의 EntityEntry 의 상태를 변경할 수 있다.")
+    @DisplayName("updateEntityEntryStatus 를 통해 person instance 의 EntityEntry 의 상태를 변경할 수 있다.")
     void updateEntityEntryStatusTest() {
-        entityEntries.addEntityEntry(entityKey, Status.LOADING);
+        entityEntries.addEntityEntry(person, Status.LOADING);
 
-        entityEntries.updateEntityEntryStatus(entityKey, Status.MANAGED);
-
-        final Optional<EntityEntry> result = entityEntries.getEntityEntry(entityKey);
+        entityEntries.updateEntityEntryStatus(person, Status.MANAGED);
+        final Optional<EntityEntry> result = entityEntries.getEntityEntry(person);
 
         assertSoftly(softly -> {
             softly.assertThat(result).isNotEmpty();
@@ -56,5 +59,31 @@ class EntityEntriesTest {
         });
     }
 
+    @Test
+    @DisplayName("updateEntityEntryStatus 를 통해 property 가 변한 person instance 의 EntityEntry 의 상태를 변경할 수 있다.")
+    void updateEntityEntryStatusWithChangedPropertyTest() {
+        entityEntries.addEntityEntry(person, Status.LOADING);
+
+        person.changeEmail("chagned@email.com");
+        entityEntries.updateEntityEntryStatus(person, Status.MANAGED);
+        final Optional<EntityEntry> result = entityEntries.getEntityEntry(person);
+
+        assertSoftly(softly -> {
+            softly.assertThat(result).isNotEmpty();
+            softly.assertThat(result.get().getStatus()).isEqualTo(Status.MANAGED);
+        });
+    }
+
+    @Test
+    @DisplayName("동등한 person instance 지만 동일하지 않은 person instance 의 EntityEntry 는 상태를 변경할 수 없다.")
+    void updateEntityEntryStatusWithDifferentPersonTest() {
+        entityEntries.addEntityEntry(person, Status.LOADING);
+
+        final Person equalPerson = FixturePerson.create(null);
+
+        assertThatThrownBy(() ->
+                entityEntries.updateEntityEntryStatus(equalPerson, Status.MANAGED)
+        ).isInstanceOf(PersistenceException.class);
+    }
 
 }

--- a/src/test/java/persistence/entity/EntityEntriesTest.java
+++ b/src/test/java/persistence/entity/EntityEntriesTest.java
@@ -1,0 +1,45 @@
+package persistence.entity;
+
+import domain.Person;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+class EntityEntriesTest {
+    private EntityEntries entityEntries;
+    private EntityKey entityKey;
+
+    @BeforeEach
+    void setUp() {
+        entityEntries = new EntityEntries();
+        entityKey = new EntityKey(Person.class, 1L);
+    }
+
+    @Test
+    @DisplayName("EntityEntries 를 통해 EntityEntry 들를 저장하고 조회할 수 있다.")
+    void entityEntriesTest() {
+        entityEntries.addEntityEntry(entityKey, Status.LOADING);
+
+        final Optional<EntityEntry> result = entityEntries.getEntityEntry(entityKey);
+
+        assertSoftly(softly -> {
+            softly.assertThat(result).isNotEmpty();
+            final EntityEntry entityEntry = result.get();
+            softly.assertThat(entityEntry.getStatus()).isEqualTo(Status.LOADING);
+        });
+    }
+
+    @Test
+    @DisplayName("EntityEntries 를 통해 없는 key 조회시 Optional.empty 가 반환된다.")
+    void getEntityEntryNotExistTest() {
+        final Optional<EntityEntry> result = entityEntries.getEntityEntry(entityKey);
+
+        assertThat(result).isEqualTo(Optional.empty());
+    }
+
+}

--- a/src/test/java/persistence/entity/EntityEntryTest.java
+++ b/src/test/java/persistence/entity/EntityEntryTest.java
@@ -1,0 +1,35 @@
+package persistence.entity;
+
+import domain.Person;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+class EntityEntryTest {
+
+    @Test
+    @DisplayName("EntityKey 를 이용해 EntityEntry 객체를 생성할 수 있다.")
+    void entityEntryCreateTest() {
+        final EntityKey entityKey = new EntityKey(Person.class, 1L);
+        final EntityEntry entityEntry = new EntityEntry(entityKey, Status.LOADING);
+
+        assertSoftly(softly -> {
+            softly.assertThat(entityEntry).isNotNull();
+            softly.assertThat(entityEntry.getStatus()).isEqualTo(Status.LOADING);
+        });
+    }
+
+    @Test
+    @DisplayName("EntityKey.updateStatus 를 이용해 EntityEntry 의 status 를 변경할 수 있다..")
+    void entityEntryUpdateStatusTest() {
+        final EntityKey entityKey = new EntityKey(Person.class, 1L);
+        final EntityEntry entityEntry = new EntityEntry(entityKey, Status.LOADING);
+        entityEntry.updateStatus(Status.MANAGED);
+
+        assertSoftly(softly -> {
+            softly.assertThat(entityEntry).isNotNull();
+            softly.assertThat(entityEntry.getStatus()).isEqualTo(Status.MANAGED);
+        });
+    }
+}

--- a/src/test/java/persistence/entity/EntityEntryTest.java
+++ b/src/test/java/persistence/entity/EntityEntryTest.java
@@ -1,7 +1,5 @@
 package persistence.entity;
 
-import domain.FixturePerson;
-import domain.Person;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -10,10 +8,9 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 class EntityEntryTest {
 
     @Test
-    @DisplayName("person instance 를 이용해 EntityEntry 객체를 생성할 수 있다.")
+    @DisplayName("EntityEntry 객체를 생성할 수 있다.")
     void entityEntryCreateTest() {
-        final Person person = FixturePerson.create(null);
-        final EntityEntry entityEntry = new EntityEntry(person, Status.LOADING);
+        final EntityEntry entityEntry = new EntityEntry(Status.LOADING);
 
         assertSoftly(softly -> {
             softly.assertThat(entityEntry).isNotNull();
@@ -22,10 +19,9 @@ class EntityEntryTest {
     }
 
     @Test
-    @DisplayName("person instance 를 이용해 EntityEntry 의 status 를 변경할 수 있다.")
+    @DisplayName("EntityEntry 의 status 를 변경할 수 있다.")
     void entityEntryUpdateStatusTest() {
-        final Person person = FixturePerson.create(null);
-        final EntityEntry entityEntry = new EntityEntry(person, Status.LOADING);
+        final EntityEntry entityEntry = new EntityEntry(Status.LOADING);
         entityEntry.updateStatus(Status.MANAGED);
 
         assertSoftly(softly -> {

--- a/src/test/java/persistence/entity/EntityEntryTest.java
+++ b/src/test/java/persistence/entity/EntityEntryTest.java
@@ -1,5 +1,6 @@
 package persistence.entity;
 
+import domain.FixturePerson;
 import domain.Person;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,10 +10,10 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 class EntityEntryTest {
 
     @Test
-    @DisplayName("EntityKey 를 이용해 EntityEntry 객체를 생성할 수 있다.")
+    @DisplayName("person instance 를 이용해 EntityEntry 객체를 생성할 수 있다.")
     void entityEntryCreateTest() {
-        final EntityKey entityKey = new EntityKey(Person.class, 1L);
-        final EntityEntry entityEntry = new EntityEntry(entityKey, Status.LOADING);
+        final Person person = FixturePerson.create(null);
+        final EntityEntry entityEntry = new EntityEntry(person, Status.LOADING);
 
         assertSoftly(softly -> {
             softly.assertThat(entityEntry).isNotNull();
@@ -21,10 +22,10 @@ class EntityEntryTest {
     }
 
     @Test
-    @DisplayName("EntityKey.updateStatus 를 이용해 EntityEntry 의 status 를 변경할 수 있다..")
+    @DisplayName("person instance 를 이용해 EntityEntry 의 status 를 변경할 수 있다.")
     void entityEntryUpdateStatusTest() {
-        final EntityKey entityKey = new EntityKey(Person.class, 1L);
-        final EntityEntry entityEntry = new EntityEntry(entityKey, Status.LOADING);
+        final Person person = FixturePerson.create(null);
+        final EntityEntry entityEntry = new EntityEntry(person, Status.LOADING);
         entityEntry.updateStatus(Status.MANAGED);
 
         assertSoftly(softly -> {

--- a/src/test/java/persistence/entity/EntityLoaderProviderTest.java
+++ b/src/test/java/persistence/entity/EntityLoaderProviderTest.java
@@ -1,13 +1,19 @@
 package persistence.entity;
 
 import domain.FixtureEntity;
+import jdbc.JdbcTemplate;
 import mock.MockDmlGenerator;
 import mock.MockJdbcTemplate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import persistence.Application;
+import persistence.sql.dml.DmlGenerator;
 
 import java.sql.SQLException;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,7 +23,16 @@ class EntityLoaderProviderTest {
 
     @BeforeEach
     void setUp() throws SQLException {
-        entityLoaderProvider = new EntityLoaderProvider(new MockDmlGenerator(), new MockJdbcTemplate());
+        entityLoaderProvider = new EntityLoaderProvider(initEntityLoaders(new MockDmlGenerator(), new MockJdbcTemplate()));
+    }
+
+    private Map<Class<?>, EntityLoader<?>> initEntityLoaders(final DmlGenerator dmlGenerator, final JdbcTemplate jdbcTemplate) {
+        final EntityScanner entityScanner = new EntityScanner(Application.class);
+        return entityScanner.getEntityClasses().stream()
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        clazz -> new EntityLoader<>(clazz, dmlGenerator, jdbcTemplate)
+                ));
     }
 
     @Test

--- a/src/test/java/persistence/entity/EntityPersisterProviderTest.java
+++ b/src/test/java/persistence/entity/EntityPersisterProviderTest.java
@@ -1,13 +1,19 @@
 package persistence.entity;
 
 import domain.FixtureEntity;
+import jdbc.JdbcTemplate;
 import mock.MockDmlGenerator;
 import mock.MockJdbcTemplate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import persistence.Application;
+import persistence.sql.dml.DmlGenerator;
 
 import java.sql.SQLException;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,7 +23,16 @@ class EntityPersisterProviderTest {
 
     @BeforeEach
     void setUp() throws SQLException {
-        entityPersisterProvider = new EntityPersisterProvider(new MockDmlGenerator(), new MockJdbcTemplate());
+        entityPersisterProvider = new EntityPersisterProvider(initEntityPersisters(new MockDmlGenerator(), new MockJdbcTemplate()));
+    }
+
+    private Map<Class<?>, EntityPersister> initEntityPersisters(final DmlGenerator dmlGenerator, final JdbcTemplate jdbcTemplate) {
+        final EntityScanner entityScanner = new EntityScanner(Application.class);
+        return entityScanner.getEntityClasses().stream()
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        clazz -> new EntityPersister(clazz, dmlGenerator, jdbcTemplate)
+                ));
     }
 
     @Test

--- a/src/test/java/persistence/entity/EntityScannerTest.java
+++ b/src/test/java/persistence/entity/EntityScannerTest.java
@@ -1,0 +1,54 @@
+package persistence.entity;
+
+import domain.FixtureEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import persistence.Application;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+class EntityScannerTest {
+
+    @Test
+    @DisplayName("EntityScanner 를 통해 특정 클래스포함, 하위 중 @Entity 를 가지고 있는 class 들을 가져올 수 있다.")
+    void entityScannerTest() {
+        final EntityScanner entityScanner = new EntityScanner(FixtureEntity.class);
+
+        final List<Class<?>> entityClasses = entityScanner.getEntityClasses();
+
+        assertSoftly(softly -> {
+            softly.assertThat(entityClasses).contains(FixtureEntity.Person.class);
+            softly.assertThat(entityClasses).doesNotContain(FixtureEntity.class);
+        });
+    }
+
+    @Test
+    @DisplayName("EntityScanner 를 통해 @EntityScanBase 를 가지고 있는 클래스 포함, 하위 중 @Entity 를 가지고 있는 class 들을 가져올 수 있다.")
+    void entityScannerWithEntityScanBaseAnnotationTest() {
+        final EntityScanner entityScanner = new EntityScanner(Application.class);
+
+        final List<Class<?>> entityClasses = entityScanner.getEntityClasses();
+
+        assertSoftly(softly -> {
+            softly.assertThat(entityClasses).contains(FixtureEntity.Person.class);
+            softly.assertThat(entityClasses).doesNotContain(FixtureEntity.class);
+        });
+    }
+
+    @Test
+    @DisplayName("EntityScanner 를 통해 특정 클래스 밑에 @Entity 를 가진 class 가 없는 경우 emptyList 를 반환한다.")
+    void entityScannerReturnEmptyTest() {
+        final EntityScanner entityScanner = new EntityScanner(NoEntityIncluded.class);
+
+        final List<Class<?>> entityClasses = entityScanner.getEntityClasses();
+
+        assertThat(entityClasses).isEmpty();
+    }
+
+    private static class NoEntityIncluded {
+
+    }
+}

--- a/src/test/java/persistence/entity/EntitySnapshotsTest.java
+++ b/src/test/java/persistence/entity/EntitySnapshotsTest.java
@@ -1,5 +1,6 @@
 package persistence.entity;
 
+import domain.FixturePerson;
 import domain.Person;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,7 +17,7 @@ class EntitySnapshotsTest {
     @BeforeEach
     void setUp() {
         entitySnapshots = new EntitySnapshots();
-        fixture = new Person(1L, "test", 0, "test@test.com");
+        fixture = FixturePerson.create(1L);
         fixtureEntityKey = new EntityKey(Person.class, 1L);
     }
 

--- a/src/test/java/persistence/entity/EntitySnapshotsTest.java
+++ b/src/test/java/persistence/entity/EntitySnapshotsTest.java
@@ -1,0 +1,47 @@
+package persistence.entity;
+
+import domain.Person;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+class EntitySnapshotsTest {
+    private EntitySnapshots entitySnapshots;
+    private Person fixture;
+    private EntityKey fixtureEntityKey;
+
+    @BeforeEach
+    void setUp() {
+        entitySnapshots = new EntitySnapshots();
+        fixture = new Person(1L, "test", 0, "test@test.com");
+        fixtureEntityKey = new EntityKey(Person.class, 1L);
+    }
+
+    @Test
+    @DisplayName("Entity 를 처음 넣는다면 동등하지만 동일하지 않은 객체를 반환한다.")
+    void firstGetDatabaseSnapshotTest() {
+        final Object databaseSnapshot = entitySnapshots.getDatabaseSnapshot(fixtureEntityKey, fixture);
+
+        assertSoftly(softly -> {
+            softly.assertThat(databaseSnapshot == fixture).isFalse();
+            softly.assertThat(databaseSnapshot.getClass()).isEqualTo(fixture.getClass());
+            final Person castedDatabaseSnapshot = fixture.getClass().cast(databaseSnapshot);
+            softly.assertThat(castedDatabaseSnapshot.getId()).isEqualTo(fixture.getId());
+            softly.assertThat(castedDatabaseSnapshot.getName()).isEqualTo(fixture.getName());
+            softly.assertThat(castedDatabaseSnapshot.getAge()).isEqualTo(fixture.getAge());
+            softly.assertThat(castedDatabaseSnapshot.getEmail()).isEqualTo(fixture.getEmail());
+        });
+    }
+
+    @Test
+    @DisplayName("두번째 getDatabaseSnapshot 부터는 첫 getDatabaseSnapshot 과 동일한 객체를 반환한다.")
+    void afterFirstGetDatabaseSnapshotTest() {
+        final Object databaseSnapshot = entitySnapshots.getDatabaseSnapshot(fixtureEntityKey, fixture);
+        final Object databaseSnapshotV2 = entitySnapshots.getDatabaseSnapshot(fixtureEntityKey, fixture);
+
+        assertThat(databaseSnapshot == databaseSnapshotV2).isTrue();
+    }
+}

--- a/src/test/java/persistence/entity/SimpleEntityManagerFactoryTest.java
+++ b/src/test/java/persistence/entity/SimpleEntityManagerFactoryTest.java
@@ -1,0 +1,22 @@
+package persistence.entity;
+
+import mock.MockPersistenceEnvironment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import persistence.Application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SimpleEntityManagerFactoryTest {
+
+    @Test
+    @DisplayName("EntityManagerFactory 를 이용해 EntityManager 를 생성할 수 있다.")
+    void test() {
+        final EntityScanner entityScanner = new EntityScanner(Application.class);
+        final EntityManagerFactory entityManagerFactory = new SimpleEntityManagerFactory(entityScanner, new MockPersistenceEnvironment());
+
+        final EntityManager entityManager = entityManagerFactory.createEntityManager();
+
+        assertThat(entityManager).isNotNull();
+    }
+}

--- a/src/test/java/persistence/entity/SimpleEntityManagerTest.java
+++ b/src/test/java/persistence/entity/SimpleEntityManagerTest.java
@@ -1,9 +1,11 @@
 package persistence.entity;
 
-import domain.Person;
+import domain.FixtureEntity.Person;
+import jdbc.RowMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import persistence.Application;
 import persistence.IntegrationTestEnvironment;
 import persistence.exception.PersistenceException;
 
@@ -19,9 +21,8 @@ class SimpleEntityManagerTest extends IntegrationTestEnvironment {
 
     @BeforeEach
     void setUp() {
-        final EntityPersisterProvider entityPersisterProvider = new EntityPersisterProvider(dmlGenerator, jdbcTemplate);
-        final EntityLoaderProvider entityLoaderProvider = new EntityLoaderProvider(dmlGenerator, jdbcTemplate);
-        entityManager = new SimpleEntityManager(entityPersisterProvider, entityLoaderProvider);
+        final EntityManagerFactory entityManagerFactory = new SimpleEntityManagerFactory(new EntityScanner(Application.class), persistenceEnvironment);
+        entityManager = entityManagerFactory.createEntityManager();
     }
 
     @Test
@@ -140,4 +141,7 @@ class SimpleEntityManagerTest extends IntegrationTestEnvironment {
         });
     }
 
+    private RowMapper<Person> personRowMapper() {
+        return rs -> new Person(rs.getLong("id"), rs.getString("nick_name"), rs.getInt("old"), rs.getString("email"));
+    }
 }

--- a/src/test/java/persistence/entity/SimplePersistenceContextTest.java
+++ b/src/test/java/persistence/entity/SimplePersistenceContextTest.java
@@ -77,37 +77,6 @@ class SimplePersistenceContextTest {
     }
 
     @Test
-    @DisplayName("같은 key로 getCachedDatabaseSnapshot 를 통해 조회한 Entity 는 항상 동일한 객체이다.")
-    void getCachedDatabaseSnapshotTest() {
-        persistenceContext.getDatabaseSnapshot(personEntityKey, person);
-
-        final Object entity = persistenceContext.getCachedDatabaseSnapshot(personEntityKey);
-        final Object entity2 = persistenceContext.getCachedDatabaseSnapshot(personEntityKey);
-
-        assertSoftly(softly -> {
-            softly.assertThat(entity).isNotNull();
-            softly.assertThat(entity2).isNotNull();
-            softly.assertThat(entity == entity2).isTrue();
-        });
-    }
-
-    @Test
-    @DisplayName("같은 key로 getEntity 와 getCachedDatabaseSnapshot 과 를 통해 조회하면 서로 다른 객체이다.")
-    void getCachedDatabaseSnapshotDifferentFromGetEntityTest() {
-        persistenceContext.addEntity(personEntityKey, person);
-        persistenceContext.getDatabaseSnapshot(personEntityKey, person);
-
-        final Object entity = persistenceContext.getEntity(personEntityKey).orElse(null);
-        final Object entity2 = persistenceContext.getCachedDatabaseSnapshot(personEntityKey);
-
-        assertSoftly(softly -> {
-            softly.assertThat(entity).isNotNull();
-            softly.assertThat(entity2).isNotNull();
-            softly.assertThat(entity == entity2).isFalse();
-        });
-    }
-
-    @Test
     @DisplayName("hasEntity 를 통해 Entity가 context 에 존재하는지 여부를 반환받을 수 있다.")
     void hasEntityTest() {
         persistenceContext.addEntity(personEntityKey, person);

--- a/src/test/java/persistence/entity/SimplePersistenceContextTest.java
+++ b/src/test/java/persistence/entity/SimplePersistenceContextTest.java
@@ -22,6 +22,7 @@ class SimplePersistenceContextTest {
         entityKeyGenerator = new EntityKeyGenerator();
         personEntityKey = entityKeyGenerator.generate(Person.class, 1L);
         person = FixturePerson.create(1L);
+        persistenceContext.addEntityEntry(person, Status.LOADING);
     }
 
     @Test

--- a/src/test/java/persistence/entity/SimplePersistenceContextTest.java
+++ b/src/test/java/persistence/entity/SimplePersistenceContextTest.java
@@ -83,4 +83,27 @@ class SimplePersistenceContextTest {
 
         assertThat(persistenceContext.hasEntity(personEntityKey)).isTrue();
     }
+
+    @Test
+    @DisplayName("addEntityEntry 를 통해 EntityEntry 를 추가한 뒤 조회할 수 있다.")
+    void addEntityEntryTest() {
+        persistenceContext.addEntityEntry(personEntityKey, Status.LOADING);
+
+        assertThat(persistenceContext.getEntityEntry(personEntityKey)).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("updateEntityEntryStatus 를 통해 EntityEntry 의 상태를 변경할 수 있다.")
+    void updateEntityEntryStatusTest() {
+        persistenceContext.addEntityEntry(personEntityKey, Status.LOADING);
+
+        persistenceContext.updateEntityEntryStatus(personEntityKey, Status.MANAGED);
+
+        assertSoftly(softly -> {
+            softly.assertThat(persistenceContext.getEntityEntry(personEntityKey)).isNotEmpty();
+            final EntityEntry entityEntry = persistenceContext.getEntityEntry(personEntityKey).get();
+            softly.assertThat(entityEntry.getStatus()).isEqualTo(Status.MANAGED);
+        });
+    }
+
 }


### PR DESCRIPTION
객체를 insert 하기 전에 `Saving` 상태로 만들어야하는데 insert 하기 전에는 key 의 채번이 되어있지 않아서 `EntityKey` 자체를 생성하기 좀 어렵다보니 어찌해야할지 모르겠더라구요...

그리고 처음에는 `PersistenceContext` 에서 `EntityEntry` 의 상태값을 관리하는 구조로 짜다가 Context 에 도달하기 전에 이미 `Loading` 상태같은 Entry 가 생성이 되어야 한다는 생각이 들어서 `EntityManager` 에서 상태값들을 관리하게 바꿨습니다. 

비슷한 이유로 `EntityEntry` 가 내부적으로 `Entity` 를 가지고 있지 않고 `EntityKey` 만 가지고 있는데 이 역시 `Loading` 상태에서는 아직 `Entity` 가 load 되지 않아서 값을 넣어줄 수 가 없더라구요.

초기에 값이 없는상태라면 일단 null 이나 대체값을 넣어두고 나중에 set 하는 방식을 가져가는게 맞는걸까요?