### PR TITLE
step1 : 엔터티 매핑 (EntityPersister)

### DIFF
--- a/src/main/java/jdbc/JdbcTemplate.java
+++ b/src/main/java/jdbc/JdbcTemplate.java
@@ -23,6 +23,7 @@ public class JdbcTemplate {
 
     public <T> T queryForObject(final String sql, final RowMapper<T> rowMapper) {
         try (final ResultSet resultSet = connection.prepareStatement(sql).executeQuery()) {
+            resultSet.next();
             return rowMapper.mapRow(resultSet);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/main/java/persistence/entity/persister/EntityPersister.java
+++ b/src/main/java/persistence/entity/persister/EntityPersister.java
@@ -1,0 +1,32 @@
+package persistence.entity.persister;
+
+import java.util.HashMap;
+import jdbc.JdbcTemplate;
+import jdbc.RowMapper;
+import persistence.sql.dml.assembler.DataManipulationLanguageAssembler;
+
+public class EntityPersister {
+    private final RowMapper<?> rowMapper;
+    private final DataManipulationLanguageAssembler dataManipulationLanguageAssembler;
+    private final JdbcTemplate jdbcTemplate;
+
+
+    public EntityPersister(RowMapper<?> rowMapper, DataManipulationLanguageAssembler dataManipulationLanguageAssembler, JdbcTemplate jdbcTemplate) {
+        this.rowMapper = rowMapper;
+        this.dataManipulationLanguageAssembler = dataManipulationLanguageAssembler;
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public boolean update(Object object) {
+        jdbcTemplate.execute(dataManipulationLanguageAssembler.generateUpdate(object));
+        return true;
+    }
+
+    public void insert(Object object) {
+        jdbcTemplate.execute(dataManipulationLanguageAssembler.generateInsert(object));
+    }
+
+    public void delete(Object object) {
+        jdbcTemplate.execute(dataManipulationLanguageAssembler.generateDeleteWithWhere(object));
+    }
+}

--- a/src/main/java/persistence/sql/dialect/Dialect.java
+++ b/src/main/java/persistence/sql/dialect/Dialect.java
@@ -3,6 +3,7 @@ package persistence.sql.dialect;
 import persistence.sql.dml.delete.DeleteQuery;
 import persistence.sql.dml.insert.InsertQuery;
 import persistence.sql.dml.select.SelectQuery;
+import persistence.sql.dml.update.UpdateQuery;
 import persistence.sql.dml.where.WhereQuery;
 
 public interface Dialect {
@@ -13,4 +14,6 @@ public interface Dialect {
     String selectConditionBuilder(SelectQuery selectQuery, WhereQuery whereQuery);
 
     String deleteBuilder(DeleteQuery deleteQuery, WhereQuery whereQuery);
+
+    String updateBuilder(UpdateQuery updateQuery);
 }

--- a/src/main/java/persistence/sql/dialect/H2Dialect.java
+++ b/src/main/java/persistence/sql/dialect/H2Dialect.java
@@ -6,6 +6,7 @@ import persistence.sql.dml.ValueClause;
 import persistence.sql.dml.delete.DeleteQuery;
 import persistence.sql.dml.insert.InsertQuery;
 import persistence.sql.dml.select.SelectQuery;
+import persistence.sql.dml.update.UpdateQuery;
 import persistence.sql.dml.where.ConditionType;
 import persistence.sql.dml.where.KeyCondition;
 import persistence.sql.dml.where.WhereQuery;
@@ -47,6 +48,25 @@ public class H2Dialect implements Dialect{
         sb.append("delete from ");
         sb.append(deleteQuery.getTableName().toString());
         whereQueryToSql(whereQuery, sb);
+        sb.append(";");
+        return sb.toString();
+    }
+
+    @Override
+    public String updateBuilder(UpdateQuery updateQuery) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("update ");
+        sb.append(updateQuery.getTableName());
+        sb.append(" set");
+        updateQuery.getColumToValueMap().forEach((columnClause, valueClause) -> {
+            sb.append(" ");
+            sb.append(columnClause.getColumnName());
+            sb.append("=");
+            sb.append(changeToSql(valueClause));
+            sb.append(",");
+        });
+        sb.deleteCharAt(sb.length() - 1);
+        whereQueryToSql(updateQuery.getWhereQuery(), sb);
         sb.append(";");
         return sb.toString();
     }

--- a/src/main/java/persistence/sql/dml/ColumnClause.java
+++ b/src/main/java/persistence/sql/dml/ColumnClause.java
@@ -3,7 +3,7 @@ package persistence.sql.dml;
 import java.util.Objects;
 
 public class ColumnClause {
-    String columnName;
+    private final String columnName;
 
     public ColumnClause(String columnName) {
         this.columnName = columnName;

--- a/src/main/java/persistence/sql/dml/assembler/DataManipulationLanguageAssembler.java
+++ b/src/main/java/persistence/sql/dml/assembler/DataManipulationLanguageAssembler.java
@@ -5,6 +5,7 @@ import persistence.sql.dml.DataManipulationLanguageGenerator;
 import persistence.sql.dml.delete.DeleteQuery;
 import persistence.sql.dml.insert.InsertQuery;
 import persistence.sql.dml.select.SelectQuery;
+import persistence.sql.dml.update.UpdateQuery;
 import persistence.sql.dml.where.WhereQuery;
 
 public class DataManipulationLanguageAssembler {
@@ -19,6 +20,11 @@ public class DataManipulationLanguageAssembler {
     public String generateInsert(Object object) {
         InsertQuery insertQuery = dataManipulationLanguageGenerator.buildInsertQuery(object);
         return dialect.insertBuilder(insertQuery);
+    }
+
+    public String generateUpdate(Object object) {
+        UpdateQuery updateQuery = dataManipulationLanguageGenerator.buildUpdateQuery(object);
+        return dialect.updateBuilder(updateQuery);
     }
 
     public String generateSelect(Class<?> cls) {

--- a/src/main/java/persistence/sql/dml/update/UpdateQuery.java
+++ b/src/main/java/persistence/sql/dml/update/UpdateQuery.java
@@ -1,0 +1,35 @@
+package persistence.sql.dml.update;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import persistence.sql.dml.ColumnClause;
+import persistence.sql.dml.ValueClause;
+import persistence.sql.dml.where.WhereQuery;
+import persistence.sql.vo.TableName;
+
+public class UpdateQuery {
+    private final TableName tableName;
+    private final WhereQuery whereQuery;
+    private final Map<ColumnClause, ValueClause> columToValueMap = new LinkedHashMap<>();
+
+    public UpdateQuery(TableName tableName, WhereQuery whereQuery) {
+        this.tableName = tableName;
+        this.whereQuery = whereQuery;
+    }
+
+    public TableName getTableName() {
+        return tableName;
+    }
+
+    public void addFieldValue(ColumnClause columnClause, ValueClause valueClause) {
+        this.columToValueMap.put(columnClause, valueClause);
+    }
+
+    public Map<ColumnClause, ValueClause> getColumToValueMap() {
+        return columToValueMap;
+    }
+
+    public WhereQuery getWhereQuery() {
+        return whereQuery;
+    }
+}

--- a/src/test/java/persistence/PersonIntegrationTest.java
+++ b/src/test/java/persistence/PersonIntegrationTest.java
@@ -103,4 +103,39 @@ class PersonIntegrationTest {
         List<Person> persons = jdbcTemplate.query(dataManipulationLanguageAssembler.generateSelect(Person.class), personRowMapper);
         assertThat(persons.size()).isZero();
     }
+
+    @DisplayName("업데이트 쿼리를 날린 후 조회하면 업데이트 된 객체가 반환된다")
+    @Test
+    void testUpdate() {
+        // given
+        Person p = new Person("tongnamuu", 14, "tongnamuu@naver.com");
+        PersonRowMapper personRowMapper = new PersonRowMapper();
+        String insertQuery = dataManipulationLanguageAssembler.generateInsert(p);
+        jdbcTemplate.execute(insertQuery);
+        Person beforeUpdatePerson = jdbcTemplate.queryForObject(
+            dataManipulationLanguageAssembler.generateSelectWithWhere(Person.class, 1L),
+            personRowMapper
+        );
+
+        // when
+        Person updatePerson = new Person("tongnamuu2", 15, "tongnamuu@gmail.com");
+        updatePerson.setId(1L);
+        String updateQuery = dataManipulationLanguageAssembler.generateUpdate(updatePerson);
+        jdbcTemplate.execute(updateQuery);
+
+        Person afterUpdatePerson = jdbcTemplate.queryForObject(
+            dataManipulationLanguageAssembler.generateSelectWithWhere(Person.class, 1L),
+            personRowMapper
+        );
+
+        // then
+        assertAll(
+            () -> assertThat(afterUpdatePerson.getName()).isEqualTo("tongnamuu2"),
+            () -> assertThat(afterUpdatePerson.getAge()).isEqualTo(15),
+            () -> assertThat(afterUpdatePerson.getEmail()).isEqualTo("tongnamuu@gmail.com"),
+            () -> assertThat(beforeUpdatePerson.getName()).isEqualTo("tongnamuu"),
+            () -> assertThat(beforeUpdatePerson.getAge()).isEqualTo(14),
+            () -> assertThat(beforeUpdatePerson.getEmail()).isEqualTo("tongnamuu@naver.com")
+        );
+    }
 }

--- a/src/test/java/persistence/entity/EntityManagerTest.java
+++ b/src/test/java/persistence/entity/EntityManagerTest.java
@@ -13,8 +13,12 @@ import jdbc.PersonRowMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import persistence.entity.persister.EntityPersister;
 import persistence.sql.ddl.assembler.DataDefinitionLanguageAssembler;
 import persistence.sql.dml.assembler.DataManipulationLanguageAssembler;
+import persistence.sql.usecase.GetFieldFromClassUseCase;
+import persistence.sql.usecase.GetFieldValueUseCase;
+import persistence.sql.usecase.GetIdDatabaseFieldUseCase;
 
 class EntityManagerTest {
     private final DataManipulationLanguageAssembler dataManipulationLanguageAssembler = createDataManipulationLanguageAssembler();
@@ -22,6 +26,7 @@ class EntityManagerTest {
     private final PersonRowMapper personRowMapper = new PersonRowMapper();
     private DatabaseServer server;
     private JdbcTemplate jdbcTemplate;
+    private EntityPersister entityPersister;
     private EntityManager entityManager;
 
 
@@ -30,7 +35,9 @@ class EntityManagerTest {
         server = new H2();
         server.start();
         jdbcTemplate = new JdbcTemplate(server.getConnection());
-        entityManager = new EntityManagerImpl(personRowMapper, dataManipulationLanguageAssembler, jdbcTemplate);
+        entityPersister = new EntityPersister(personRowMapper, dataManipulationLanguageAssembler, jdbcTemplate);
+        entityManager = new EntityManagerImpl(personRowMapper, dataManipulationLanguageAssembler,
+            jdbcTemplate, entityPersister, new GetIdDatabaseFieldUseCase(new GetFieldFromClassUseCase()), new GetFieldValueUseCase());
         jdbcTemplate.execute(dataDefinitionLanguageAssembler.assembleCreateTableQuery(Person.class));
     }
 

--- a/src/test/java/persistence/sql/dml/assembler/DataManipulationLanguageAssemblerH2Test.java
+++ b/src/test/java/persistence/sql/dml/assembler/DataManipulationLanguageAssemblerH2Test.java
@@ -61,6 +61,20 @@ class DataManipulationLanguageAssemblerH2Test {
         assertThat(sql).isEqualTo(expected);
     }
 
+    @Test
+    void generateUpdateWithWhere() {
+        // given
+        Person person = new Person("tongnamuu", 11, "tongnamuu@naver.com");
+        person.setId(2L);
+
+        // when
+        String sql = dataManipulationLanguageAssembler.generateUpdate(person);
+
+        // then
+        String expected = "update users set nick_name='tongnamuu', old=11, email='tongnamuu@naver.com' where id = 2;";
+        assertThat(sql).isEqualTo(expected);
+    }
+
     private DataManipulationLanguageAssembler createDataManipulationLanguageAssembler() {
         H2Dialect h2Dialect = new H2Dialect();
         GetTableNameFromClassUseCase getTableNameFromClassUseCase = new GetTableNameFromClassUseCase();


### PR DESCRIPTION
안녕하세요 리뷰어님.
- update 쿼리를 이전에 구현하지 않아서 추가했습니다.
- id가 null 이면 insert, 있으면 update 를 하도록 했습니다. 다만 id를 UUID 등으로 코드상에서 넣어줘서 사용하는 경우엔 적절하지 않을 수도 있을 것 같습니다. 이 부분은 2단계 엔티티 로더 및 find 쪽을 진행할 때 Entity 상태 관리를 추가해서 해결해보도록 하겠습니다.
- 사소하지만 JdbcTemplate 의 queryForObject 메서드에 `resultSet.next();` 가 빠져서 동작하지 않고 있는 것 같아서 수정했습니다.