### PR TITLE
2주차 Step4 EntityEntry PR 드립니다

### DIFF
--- a/src/main/java/persistence/entity/EntityEntry.java
+++ b/src/main/java/persistence/entity/EntityEntry.java
@@ -1,0 +1,9 @@
+package persistence.entity;
+
+public interface EntityEntry {
+
+  void putEntityEntryStatus(Object entity, EntityStatus entityEntryStatus);
+
+  EntityStatus getEntityStatus(Object entity);
+
+}

--- a/src/main/java/persistence/entity/EntityKey.java
+++ b/src/main/java/persistence/entity/EntityKey.java
@@ -12,10 +12,6 @@ public class EntityKey {
     this.id = id;
   }
 
-  public Long getId() {
-    return id;
-  }
-
   @Override
   public int hashCode() {
     return Objects.hash(clazz, id);

--- a/src/main/java/persistence/entity/EntityKey.java
+++ b/src/main/java/persistence/entity/EntityKey.java
@@ -12,6 +12,10 @@ public class EntityKey {
     this.id = id;
   }
 
+  public Long getId() {
+    return id;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(clazz, id);

--- a/src/main/java/persistence/entity/EntityLoader.java
+++ b/src/main/java/persistence/entity/EntityLoader.java
@@ -1,8 +1,11 @@
 package persistence.entity;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface EntityLoader<T> {
-  <T> T load(Long id);
+  <T> Optional<T> load(Long id);
   List<T> findAll();
+
+  List<T> loadByIds(List<Long> ids);
 }

--- a/src/main/java/persistence/entity/EntityManager.java
+++ b/src/main/java/persistence/entity/EntityManager.java
@@ -7,4 +7,5 @@ public interface EntityManager {
 
   <T> void remove(T entity);
 
+  <T> void sync();
 }

--- a/src/main/java/persistence/entity/EntityPersister.java
+++ b/src/main/java/persistence/entity/EntityPersister.java
@@ -10,7 +10,7 @@ public interface EntityPersister<T> {
 
   void delete(T entity);
 
-  T load(Long id);
+  Optional<T> load(Long id);
 
   boolean entityExists(Object entity);
 

--- a/src/main/java/persistence/entity/EntityStatus.java
+++ b/src/main/java/persistence/entity/EntityStatus.java
@@ -1,0 +1,10 @@
+package persistence.entity;
+
+public enum EntityStatus {
+  MANAGED,
+  READ_ONLY,
+  DELETED,
+  GONE,
+  LOADING,
+  SAVING
+}

--- a/src/main/java/persistence/entity/JdbcEntityEntry.java
+++ b/src/main/java/persistence/entity/JdbcEntityEntry.java
@@ -1,0 +1,18 @@
+package persistence.entity;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class JdbcEntityEntry implements EntityEntry{
+  private final Map<Integer, EntityStatus> entityEntry = new ConcurrentHashMap<>();
+
+  @Override
+  public void putEntityEntryStatus(Object entity, EntityStatus entityEntryStatus) {
+    entityEntry.put(entity.hashCode(), entityEntryStatus);
+  }
+
+  @Override
+  public EntityStatus getEntityStatus(Object entity) {
+    return entityEntry.get(entity.hashCode());
+  }
+}

--- a/src/main/java/persistence/entity/JdbcEntityLoader.java
+++ b/src/main/java/persistence/entity/JdbcEntityLoader.java
@@ -2,6 +2,8 @@ package persistence.entity;
 
 import java.sql.Connection;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import jdbc.JdbcRowMapper;
 import jdbc.JdbcTemplate;
 import persistence.meta.MetaDataColumn;
@@ -22,20 +24,38 @@ public class JdbcEntityLoader<T> implements EntityLoader<T> {
   }
 
   @Override
-  public T load(Long id) {
+  public Optional<T> load(Long id) {
     MetaDataColumn keyColumn = metaEntity.getPrimaryKeyColumn();
     String targetColumn = keyColumn.getDBColumnName();
 
     String query = selectQueryBuilder.createSelectByFieldQuery(metaEntity.getColumnClauseWithId(),
         metaEntity.getTableName(), targetColumn, id);
 
-    return jdbcTemplate.queryForObject(query, jdbcRowMapper);
+    try {
+      return Optional.ofNullable(jdbcTemplate.queryForObject(query, jdbcRowMapper));
+    } catch (RuntimeException e) {
+      return Optional.empty();
+    }
+
   }
 
   @Override
   public List<T> findAll() {
     String query = selectQueryBuilder.createSelectQuery(metaEntity.getColumnClauseWithId(),
         metaEntity.getTableName());
+    return jdbcTemplate.query(query, jdbcRowMapper);
+  }
+
+  @Override
+  public List<T> loadByIds(List<Long> ids) {
+    MetaDataColumn keyColumn = metaEntity.getPrimaryKeyColumn();
+    String targetColumn = keyColumn.getDBColumnName();
+
+    List<String> idValues = ids.stream().map(id -> id.toString()).collect(Collectors.toList());
+
+    String query = selectQueryBuilder.createSelectByFieldsQuery(metaEntity.getColumnClauseWithId(),
+        metaEntity.getTableName(), targetColumn, idValues);
+
     return jdbcTemplate.query(query, jdbcRowMapper);
   }
 }

--- a/src/main/java/persistence/entity/JdbcEntityManager.java
+++ b/src/main/java/persistence/entity/JdbcEntityManager.java
@@ -32,7 +32,11 @@ public class JdbcEntityManager implements EntityManager {
             persistenceContext.putDatabaseSnapshot(id, nullable);
           });
 
-          return entity;
+          if (entity.isPresent()) {
+            return entity.get();
+          }
+
+          return null;
         });
   }
 
@@ -44,7 +48,8 @@ public class JdbcEntityManager implements EntityManager {
 
     Long assignedId = persister.getEntityId(entity).orElse(-1L);
 
-    if (persister.entityExists(entity) && !persistenceContext.isSameWithSnapshot(assignedId, entity)) {
+    if (persister.entityExists(entity) && !persistenceContext.isSameWithSnapshot(assignedId,
+        entity)) {
       persister.update(entity);
       persistenceContext.putDatabaseSnapshot(assignedId, entity);
       persistenceContext.addEntity(assignedId, entity);
@@ -67,10 +72,10 @@ public class JdbcEntityManager implements EntityManager {
   }
 
   @Override
-  public void sync(){
+  public void sync() {
     List<Object> entites = persistenceContext.dirtyCheckedEntities();
     entites
-      .forEach(this::persist);
+        .forEach(this::persist);
   }
 
 }

--- a/src/main/java/persistence/entity/JdbcEntityPersister.java
+++ b/src/main/java/persistence/entity/JdbcEntityPersister.java
@@ -2,7 +2,6 @@ package persistence.entity;
 
 import java.sql.Connection;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import jdbc.JdbcTemplate;
@@ -74,13 +73,13 @@ public class JdbcEntityPersister<T> implements EntityPersister<T> {
   }
 
   public void throwExceptionIfNotExists(Long id, Object entity) {
-    if (Objects.isNull(load(id)) && metaEntity.getPrimaryKeyColumnIsNull(entity)) {
+    if (load(id).isEmpty() && metaEntity.getPrimaryKeyColumnIsNonNull(entity)) {
       throw new RuntimeException("해당 객체는 존재 하지 않습니다.");
     }
   }
   @Override
   public boolean entityExists(Object entity) {
-    return metaEntity.getPrimaryKeyColumnIsNull(entity) ||
+    return metaEntity.getPrimaryKeyColumnIsNonNull(entity) &&
           entityLoader.load(metaEntity.getPrimaryKeyColumnValue(entity)).isPresent();
   }
   @Override

--- a/src/main/java/persistence/entity/JdbcEntityPersister.java
+++ b/src/main/java/persistence/entity/JdbcEntityPersister.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import jdbc.JdbcTemplate;
 import persistence.meta.MetaDataColumn;
 import persistence.meta.MetaDataColumns;
@@ -35,7 +36,7 @@ public class JdbcEntityPersister<T> implements EntityPersister<T> {
     List<String> extractValuesFromEntity = metaEntity.extractValuesFromEntity(fields, entity);
     List<String> dbColumns = fields.stream()
         .map(field -> metaDataColumns.getColumnByFieldName(field).getDBColumnName())
-        .toList();
+        .collect(Collectors.toList());
 
     throwExceptionIfNotExists((Long) id, entity);
 
@@ -79,14 +80,19 @@ public class JdbcEntityPersister<T> implements EntityPersister<T> {
   }
   @Override
   public boolean entityExists(Object entity) {
-    return metaEntity.getPrimaryKeyColumnIsNull(entity);
+    return metaEntity.getPrimaryKeyColumnIsNull(entity) ||
+          entityLoader.load(metaEntity.getPrimaryKeyColumnValue(entity)).isPresent();
   }
   @Override
   public Optional<Long> getEntityId(Object entity) {
     return Optional.ofNullable(metaEntity.getPrimaryKeyColumnValue(entity));
   }
 
-  public T load(Long id) {
+  public Optional<T> load(Long id) {
     return entityLoader.load(id);
+  }
+
+  public List<T> loadAll(List<Long> ids) {
+    return entityLoader.loadByIds(ids);
   }
 }

--- a/src/main/java/persistence/entity/JdbcPersistenceContext.java
+++ b/src/main/java/persistence/entity/JdbcPersistenceContext.java
@@ -52,4 +52,10 @@ public class JdbcPersistenceContext implements PersistenceContext {
   public void putEntityEntryStatus(Object entity, EntityStatus entityEntryStatus) {
     entityEntry.put(entity.hashCode(), entityEntryStatus);
   }
+
+  @Override
+  public EntityStatus getEntityStatus(Object entity) {
+    return entityEntry.get(entity.hashCode());
+  }
+
 }

--- a/src/main/java/persistence/entity/JdbcPersistenceContext.java
+++ b/src/main/java/persistence/entity/JdbcPersistenceContext.java
@@ -1,8 +1,10 @@
 package persistence.entity;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import util.CloneUtils;
 
 public class JdbcPersistenceContext implements PersistenceContext {
@@ -35,6 +37,15 @@ public class JdbcPersistenceContext implements PersistenceContext {
   public <T> boolean isSameWithSnapshot(Long id, T entity) {
     Object snapshot = entitySnapshot.get(new EntityKey(entity.getClass(), id));
     return entity.equals(snapshot);
+  }
+
+  @Override
+  public List<Object> dirtyCheckedEntities() {
+    return entityCache.entrySet()
+        .stream()
+        .filter(entry -> !isSameWithSnapshot(entry.getKey().getId(), entry.getValue().getClass()))
+        .map(entry -> entry.getValue())
+        .collect(Collectors.toList());
   }
 
 }

--- a/src/main/java/persistence/entity/JdbcPersistenceContext.java
+++ b/src/main/java/persistence/entity/JdbcPersistenceContext.java
@@ -11,6 +11,7 @@ public class JdbcPersistenceContext implements PersistenceContext {
 
   private final Map<EntityKey, Object> entityCache = new ConcurrentHashMap<>();
   private final Map<EntityKey, Object> entitySnapshot = new ConcurrentHashMap<>();
+  private final Map<Integer, EntityStatus> entityEntry = new ConcurrentHashMap<>();
 
   @Override
   public Optional<Object> getEntity(Long id, Class<?> clazz) {
@@ -48,4 +49,7 @@ public class JdbcPersistenceContext implements PersistenceContext {
         .collect(Collectors.toList());
   }
 
+  public void putEntityEntryStatus(Object entity, EntityStatus entityEntryStatus) {
+    entityEntry.put(entity.hashCode(), entityEntryStatus);
+  }
 }

--- a/src/main/java/persistence/entity/PersistenceContext.java
+++ b/src/main/java/persistence/entity/PersistenceContext.java
@@ -1,5 +1,6 @@
 package persistence.entity;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PersistenceContext {
@@ -13,4 +14,6 @@ public interface PersistenceContext {
   <T> void putDatabaseSnapshot(Long id, T entity);
 
   <T> boolean isSameWithSnapshot(Long id, T entity);
+
+  List<Object> dirtyCheckedEntities();
 }

--- a/src/main/java/persistence/entity/PersistenceContext.java
+++ b/src/main/java/persistence/entity/PersistenceContext.java
@@ -16,4 +16,6 @@ public interface PersistenceContext {
   <T> boolean isSameWithSnapshot(Long id, T entity);
 
   List<Object> dirtyCheckedEntities();
+
+  void putEntityEntryStatus(Object entity, EntityStatus entityStatus);
 }

--- a/src/main/java/persistence/entity/PersistenceContext.java
+++ b/src/main/java/persistence/entity/PersistenceContext.java
@@ -16,8 +16,5 @@ public interface PersistenceContext {
   <T> boolean isSameWithSnapshot(Long id, T entity);
 
   List<Object> dirtyCheckedEntities();
-
-  void putEntityEntryStatus(Object entity, EntityStatus entityStatus);
-
-  EntityStatus getEntityStatus(Object entity);
+  
 }

--- a/src/main/java/persistence/entity/PersistenceContext.java
+++ b/src/main/java/persistence/entity/PersistenceContext.java
@@ -18,4 +18,6 @@ public interface PersistenceContext {
   List<Object> dirtyCheckedEntities();
 
   void putEntityEntryStatus(Object entity, EntityStatus entityStatus);
+
+  EntityStatus getEntityStatus(Object entity);
 }

--- a/src/main/java/persistence/meta/MetaEntity.java
+++ b/src/main/java/persistence/meta/MetaEntity.java
@@ -33,7 +33,7 @@ public class MetaEntity<T> {
   public MetaDataColumn getPrimaryKeyColumn() {
     return primaryKeyColumn;
   }
-  public boolean getPrimaryKeyColumnIsNull(Object entity) {
+  public boolean getPrimaryKeyColumnIsNonNull(Object entity) {
     return Objects.nonNull(primaryKeyColumn.getFieldValue(entity));
   }
 

--- a/src/main/java/persistence/repository/CustomJpaRepository.java
+++ b/src/main/java/persistence/repository/CustomJpaRepository.java
@@ -1,5 +1,6 @@
 package persistence.repository;
 
+import java.util.Optional;
 import persistence.entity.EntityManager;
 
 public class CustomJpaRepository <T, ID> {
@@ -14,7 +15,7 @@ public class CustomJpaRepository <T, ID> {
     return entity;
   }
 
-  public T findById(T entity, Long id){
-    return (T) entityManager.find(entity.getClass(), id);
+  public Optional<T> findById(T entity, Long id){
+    return (Optional<T>) entityManager.find(entity.getClass(), id);
   }
 }

--- a/src/main/java/persistence/sql/dml/builder/DmlQueryBuilder.java
+++ b/src/main/java/persistence/sql/dml/builder/DmlQueryBuilder.java
@@ -6,7 +6,6 @@ public class DmlQueryBuilder {
   private final InsertQueryBuilder insertQueryBuilder = new InsertQueryBuilder();
   private final DeleteQueryBuilder deleteQueryBuilder = new DeleteQueryBuilder();
   private final UpdateQueryBuilder updateQueryBuilder = new UpdateQueryBuilder();
-
   public DmlQueryBuilder() {
   }
 
@@ -21,5 +20,4 @@ public class DmlQueryBuilder {
   public String createDeleteQuery(String tableName, String targetName, Object targetValue){
     return deleteQueryBuilder.createDeleteQuery(tableName, targetName, targetValue);
   }
-
 }

--- a/src/main/java/persistence/sql/dml/builder/SelectQueryBuilder.java
+++ b/src/main/java/persistence/sql/dml/builder/SelectQueryBuilder.java
@@ -1,10 +1,13 @@
 package persistence.sql.dml.builder;
 
+import java.util.List;
+
 public class SelectQueryBuilder {
   private static final String SELECT_SQL_QUERY = "SELECT %s FROM %s;";
   private static final String SELECT_WHERE_SQL_QUERY = "SELECT %s FROM %s WHERE %s=%s;";
-
-
+  private static final String SELECT_WHERE_IN_SQL_QUERY = "SELECT %s FROM %s WHERE %s";
+  private static final String SELECT_WHERE_CLAUSE = "%s IN (%s)";
+  private static final String DELIMITER = ",";
   public String createSelectQuery(String columnClause, String tableName) {
 
     return String.format(SELECT_SQL_QUERY, columnClause, tableName);
@@ -15,5 +18,10 @@ public class SelectQueryBuilder {
     return String.format(SELECT_WHERE_SQL_QUERY, columnClause, tableName, targetName, targetValue);
   }
 
+  public String createSelectByFieldsQuery(String columnClause, String tableName, String targetName, List<String> targetValue) {
+    String ids = String.join(DELIMITER, targetValue);
+    String whereClause = String.format(SELECT_WHERE_CLAUSE, targetName, ids);
+    return String.format(SELECT_WHERE_IN_SQL_QUERY, columnClause, tableName, whereClause);
+  }
 
 }

--- a/src/main/java/util/CloneUtils.java
+++ b/src/main/java/util/CloneUtils.java
@@ -6,6 +6,10 @@ import java.lang.reflect.InvocationTargetException;
 
 public class CloneUtils {
 
+  private CloneUtils() {
+
+  }
+
   public static Object clone(Object entity) {
     try {
       Class<?> clazz = entity.getClass();

--- a/src/test/java/persistence/entity/JdbcEntityLoaderTest.java
+++ b/src/test/java/persistence/entity/JdbcEntityLoaderTest.java
@@ -14,8 +14,8 @@ public class JdbcEntityLoaderTest extends BuilderTest {
   @DisplayName("Loader를 이용해서 find 합니다.")
   public void findEntity() {
     JdbcEntityLoader<PersonFixtureStep3> jdbcEntityLoader = new JdbcEntityLoader<>(PersonFixtureStep3.class, connection);
-
-    PersonFixtureStep3 person = jdbcEntityLoader.load(2L);
+    List<PersonFixtureStep3> people = jdbcEntityLoader.findAll();
+    PersonFixtureStep3 person = jdbcEntityLoader.load(2L).get();
 
     assertThat(person).isEqualTo(PersonInstances.두번째사람);
   }

--- a/src/test/java/persistence/entity/JdbcEntityManagerTest.java
+++ b/src/test/java/persistence/entity/JdbcEntityManagerTest.java
@@ -7,63 +7,67 @@ import persistence.sql.fixture.PersonFixtureStep3;
 import persistence.sql.fixture.PersonInstances;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
 
 public class JdbcEntityManagerTest extends BuilderTest {
   @Test
   @DisplayName("EntityManager를 이용해서 find 합니다.")
   public void findEntity() {
-    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext);
+    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext,
+        entityEntry);
 
     PersonFixtureStep3 person = jdbcEntityManager.find(PersonFixtureStep3.class, 2L);
 
     assertThat(person).isEqualTo(PersonInstances.두번째사람);
-    assertThat(persistenceContext.getEntityStatus(PersonInstances.두번째사람)).isEqualTo(EntityStatus.MANAGED);
+    assertThat(entityEntry.getEntityStatus(PersonInstances.두번째사람)).isEqualTo(EntityStatus.MANAGED);
   }
 
   @Test
   @DisplayName("EntityManager를 이용해서 persist 합니다.")
   public void persistEntity() {
-    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext);
+    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext,
+        entityEntry);
 
     jdbcEntityManager.persist(PersonInstances.세번째사람);
 
-    assertThat(persistenceContext.getEntityStatus(PersonInstances.세번째사람)).isEqualTo(EntityStatus.MANAGED);
+    assertThat(entityEntry.getEntityStatus(PersonInstances.세번째사람)).isEqualTo(EntityStatus.MANAGED);
 
     PersonFixtureStep3 person = jdbcEntityManager.find(PersonFixtureStep3.class, 3L);
 
     assertThat(person).isEqualTo(PersonInstances.세번째사람);
-    assertThat(persistenceContext.getEntityStatus(PersonInstances.세번째사람)).isEqualTo(EntityStatus.LOADING);
+    assertThat(entityEntry.getEntityStatus(PersonInstances.세번째사람)).isEqualTo(EntityStatus.LOADING);
   }
 
   @Test
   @DisplayName("EntityManager를 이용해서 remove 하고 조회하였을 때, 해당 row가 없습니다.")
   public void removeEntity() {
-    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext);
+    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext,
+        entityEntry);
 
     jdbcEntityManager.remove(PersonInstances.첫번째사람);
     PersonFixtureStep3 person = jdbcEntityManager.find(PersonFixtureStep3.class, 1L);
 
     assertThat(person).isEqualTo(null);
-    assertThat(persistenceContext.getEntityStatus(PersonInstances.첫번째사람)).isEqualTo(EntityStatus.GONE);
+    assertThat(entityEntry.getEntityStatus(PersonInstances.첫번째사람)).isEqualTo(EntityStatus.GONE);
   }
   @Test
   @DisplayName("find시에 1차 캐시에 저장된 entity를 가져온다.")
   public void findEntityWithPersistenceContext() {
-    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext);
+    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext,
+        entityEntry);
 
     jdbcEntityManager.persist(PersonInstances.두번째사람);
     PersonFixtureStep3 person = jdbcEntityManager.find(PersonFixtureStep3.class, 2L);
 
     assertThat(person).isEqualTo(PersonInstances.두번째사람);
     assertThat(person == PersonInstances.두번째사람).isEqualTo(true);
-    assertThat(persistenceContext.getEntityStatus(PersonInstances.두번째사람)).isEqualTo(EntityStatus.LOADING);
+    assertThat(entityEntry.getEntityStatus(PersonInstances.두번째사람)).isEqualTo(EntityStatus.LOADING);
   }
 
   @Test
   @DisplayName("persist시에 1차 캐시의 entity와 snapshot의 값이 다르면 더티체킹으로 업데이트한다.")
   public void persistDiffEntityWithPersistenceContext() {
-    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext);
+    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext,
+        entityEntry);
 
     PersonFixtureStep3 person = jdbcEntityManager.find(PersonFixtureStep3.class, 2L);
     person.setName("Sichngpark");

--- a/src/test/java/persistence/entity/JdbcEntityManagerTest.java
+++ b/src/test/java/persistence/entity/JdbcEntityManagerTest.java
@@ -45,7 +45,7 @@ public class JdbcEntityManagerTest extends BuilderTest {
     assertThat(thrown).isInstanceOf(RuntimeException.class);
   }
   @Test
-  @DisplayName("find시에 Persistence Context 저장된 entity를 가져온다.")
+  @DisplayName("find시에 1차 캐시에 저장된 entity를 가져온다.")
   public void findEntityWithPersistenceContext() {
     JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext);
 
@@ -53,10 +53,11 @@ public class JdbcEntityManagerTest extends BuilderTest {
     PersonFixtureStep3 person = jdbcEntityManager.find(PersonFixtureStep3.class, 2L);
 
     assertThat(person).isEqualTo(PersonInstances.두번째사람);
+    assertThat(person == PersonInstances.두번째사람).isEqualTo(true);
   }
 
   @Test
-  @DisplayName("persist시에 Persistence Context의 entity와 다르면 더티체킹으로 업데이트한다.")
+  @DisplayName("persist시에 1차 캐시의 entity와 snapshot의 값이 다르면 더티체킹으로 업데이트한다.")
   public void persistDiffEntityWithPersistenceContext() {
     JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext);
 

--- a/src/test/java/persistence/entity/JdbcEntityManagerTest.java
+++ b/src/test/java/persistence/entity/JdbcEntityManagerTest.java
@@ -18,6 +18,7 @@ public class JdbcEntityManagerTest extends BuilderTest {
     PersonFixtureStep3 person = jdbcEntityManager.find(PersonFixtureStep3.class, 2L);
 
     assertThat(person).isEqualTo(PersonInstances.두번째사람);
+    assertThat(persistenceContext.getEntityStatus(PersonInstances.두번째사람)).isEqualTo(EntityStatus.MANAGED);
   }
 
   @Test
@@ -27,9 +28,12 @@ public class JdbcEntityManagerTest extends BuilderTest {
 
     jdbcEntityManager.persist(PersonInstances.세번째사람);
 
+    assertThat(persistenceContext.getEntityStatus(PersonInstances.세번째사람)).isEqualTo(EntityStatus.MANAGED);
+
     PersonFixtureStep3 person = jdbcEntityManager.find(PersonFixtureStep3.class, 3L);
 
     assertThat(person).isEqualTo(PersonInstances.세번째사람);
+    assertThat(persistenceContext.getEntityStatus(PersonInstances.세번째사람)).isEqualTo(EntityStatus.LOADING);
   }
 
   @Test
@@ -38,11 +42,10 @@ public class JdbcEntityManagerTest extends BuilderTest {
     JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext);
 
     jdbcEntityManager.remove(PersonInstances.첫번째사람);
+    PersonFixtureStep3 person = jdbcEntityManager.find(PersonFixtureStep3.class, 1L);
 
-    Throwable thrown = catchThrowable(() -> {
-      jdbcEntityManager.find(PersonFixtureStep3.class, 1L);
-    });
-    assertThat(thrown).isInstanceOf(RuntimeException.class);
+    assertThat(person).isEqualTo(null);
+    assertThat(persistenceContext.getEntityStatus(PersonInstances.첫번째사람)).isEqualTo(EntityStatus.GONE);
   }
   @Test
   @DisplayName("find시에 1차 캐시에 저장된 entity를 가져온다.")
@@ -54,6 +57,7 @@ public class JdbcEntityManagerTest extends BuilderTest {
 
     assertThat(person).isEqualTo(PersonInstances.두번째사람);
     assertThat(person == PersonInstances.두번째사람).isEqualTo(true);
+    assertThat(persistenceContext.getEntityStatus(PersonInstances.두번째사람)).isEqualTo(EntityStatus.LOADING);
   }
 
   @Test

--- a/src/test/java/persistence/entity/JdbcEntityPersisterTest.java
+++ b/src/test/java/persistence/entity/JdbcEntityPersisterTest.java
@@ -50,10 +50,7 @@ public class JdbcEntityPersisterTest extends BuilderTest {
 
     persister.delete(PersonInstances.두번째사람);
 
-    Throwable thrown = catchThrowable(() -> {
-      jdbcEntityManager.find(PersonFixtureStep3.class, 2L);
-    });
-    assertThat(thrown).isInstanceOf(RuntimeException.class);
+    assertThat(jdbcEntityManager.find(PersonFixtureStep3.class, 3L)).isEqualTo(null);
   }
 
   @Test

--- a/src/test/java/persistence/entity/JdbcEntityPersisterTest.java
+++ b/src/test/java/persistence/entity/JdbcEntityPersisterTest.java
@@ -14,7 +14,8 @@ public class JdbcEntityPersisterTest extends BuilderTest {
   @Test
   @DisplayName("Persister를 이용해서 insert 합니다.")
   public void persisterInsertEntity() {
-    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext);
+    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext,
+        entityEntry);
     JdbcEntityPersister<PersonFixtureStep3> persister = new JdbcEntityPersister<>(PersonFixtureStep3.class, connection);
     PersonFixtureStep3 네번째사람 = new PersonFixtureStep3(3L, "헨드릭스", 24, "sdafij@gmail.com");
 
@@ -27,7 +28,8 @@ public class JdbcEntityPersisterTest extends BuilderTest {
   @Test
   @DisplayName("Persister를 이용해서 update 합니다.")
   public void persisterUpdateEntity() {
-    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext);
+    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext,
+        entityEntry);
     JdbcEntityPersister<PersonFixtureStep3> persister = new JdbcEntityPersister<>(PersonFixtureStep3.class, connection);
     PersonFixtureStep3 업데이트된세번째사람 = new PersonFixtureStep3(3L, "헨드릭스", 24, "sdafij@gmail.com");
 
@@ -44,7 +46,8 @@ public class JdbcEntityPersisterTest extends BuilderTest {
   @Test
   @DisplayName("Persister를 이용해서 delete 합니다.")
   public void persisterDeleteEntity() {
-    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext);
+    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext,
+        entityEntry);
     JdbcEntityPersister<PersonFixtureStep3> persister = new JdbcEntityPersister<>(PersonFixtureStep3.class, connection);
     persister.insert(PersonInstances.두번째사람);
 
@@ -56,7 +59,8 @@ public class JdbcEntityPersisterTest extends BuilderTest {
   @Test
   @DisplayName("Persister를 이용해서 존재하지 않는 entity를 remove 되지 않습니다.")
   public void removeNotExistingEntity() {
-    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext);
+    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext,
+        entityEntry);
     JdbcEntityPersister<PersonFixtureStep3> persister = new JdbcEntityPersister<>(PersonFixtureStep3.class, connection);
     PersonFixtureStep3 다섯번째사람 = new PersonFixtureStep3(5L, "버락", 24, "sdafij@gmail.com");
 
@@ -71,7 +75,8 @@ public class JdbcEntityPersisterTest extends BuilderTest {
   @Test
   @DisplayName("Persister를 이용해서 존재하지 않는 entity를 update 되지 않습니다.")
   public void updateNotExistingEntity() {
-    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext);
+    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext,
+        entityEntry);
     JdbcEntityPersister<PersonFixtureStep3> persister = new JdbcEntityPersister<>(PersonFixtureStep3.class, connection);
     PersonFixtureStep3 다섯번째사람 = new PersonFixtureStep3(5L, "버락", 24, "sdafij@gmail.com");
 

--- a/src/test/java/persistence/entity/JdbcPersistenceContextTest.java
+++ b/src/test/java/persistence/entity/JdbcPersistenceContextTest.java
@@ -23,6 +23,7 @@ public class JdbcPersistenceContextTest extends BuilderTest {
         PersonInstances.첫번째사람.getClass()).get();
 
     assertThat(entity).isEqualTo(PersonInstances.첫번째사람);
+    assertThat(entity == PersonInstances.첫번째사람).isEqualTo(true);
   }
 
   @Test

--- a/src/test/java/persistence/repository/CustomJpaRepositoryTest.java
+++ b/src/test/java/persistence/repository/CustomJpaRepositoryTest.java
@@ -15,7 +15,8 @@ public class CustomJpaRepositoryTest extends BuilderTest {
   @Test
   @DisplayName("entity를 저장합니다.")
   void saveEntity(){
-    customJpaRepository = new CustomJpaRepository<>(new JdbcEntityManager(connection, persistenceContext));
+    customJpaRepository = new CustomJpaRepository<>(new JdbcEntityManager(connection, persistenceContext,
+        entityEntry));
     PersonFixtureStep3 person = customJpaRepository.save(PersonInstances.세번째사람);
 
     PersonFixtureStep3 personFound = customJpaRepository.findById(person, person.getId()).get();
@@ -27,7 +28,8 @@ public class CustomJpaRepositoryTest extends BuilderTest {
   @Test
   @DisplayName("영속화된 entity를 변경감지로 수정된 entity로 persist 합니다.")
   void persistUpdatedEntity(){
-    customJpaRepository = new CustomJpaRepository<>(new JdbcEntityManager(connection, persistenceContext));
+    customJpaRepository = new CustomJpaRepository<>(new JdbcEntityManager(connection, persistenceContext,
+        entityEntry));
     PersonFixtureStep3 person = customJpaRepository.save(PersonInstances.세번째사람);
 
     customJpaRepository.save(person);

--- a/src/test/java/persistence/repository/CustomJpaRepositoryTest.java
+++ b/src/test/java/persistence/repository/CustomJpaRepositoryTest.java
@@ -18,7 +18,7 @@ public class CustomJpaRepositoryTest extends BuilderTest {
     customJpaRepository = new CustomJpaRepository<>(new JdbcEntityManager(connection, persistenceContext));
     PersonFixtureStep3 person = customJpaRepository.save(PersonInstances.세번째사람);
 
-    PersonFixtureStep3 personFound = customJpaRepository.findById(person, person.getId());
+    PersonFixtureStep3 personFound = customJpaRepository.findById(person, person.getId()).get();
 
     assertThat(personFound.getId()).isEqualTo(person.getId());
     assertThat(personFound.getName()).isEqualTo(person.getName());
@@ -34,7 +34,7 @@ public class CustomJpaRepositoryTest extends BuilderTest {
     person.setName("사이먼팍");
     customJpaRepository.save(person);
 
-    PersonFixtureStep3 personFound = customJpaRepository.findById(person, person.getId());
+    PersonFixtureStep3 personFound = customJpaRepository.findById(person, person.getId()).get();
     assertThat(personFound.getId()).isEqualTo(person.getId());
     assertThat(personFound.getName()).isEqualTo(person.getName());
   }

--- a/src/test/java/persistence/sql/ddl/builder/BuilderTest.java
+++ b/src/test/java/persistence/sql/ddl/builder/BuilderTest.java
@@ -5,6 +5,7 @@ import database.H2;
 import java.sql.Connection;
 import java.sql.SQLException;
 import jdbc.JdbcTemplate;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,7 +62,7 @@ public class BuilderTest {
   void delete() {
     persistenceContext = new JdbcPersistenceContext();
 
-    String queryFirst = "truncate table USERS";
+    String queryFirst = "truncate table USERS RESTART IDENTITY" ;
     jdbcTemplate.execute(queryFirst);
   }
 

--- a/src/test/java/persistence/sql/ddl/builder/BuilderTest.java
+++ b/src/test/java/persistence/sql/ddl/builder/BuilderTest.java
@@ -5,10 +5,11 @@ import database.H2;
 import java.sql.Connection;
 import java.sql.SQLException;
 import jdbc.JdbcTemplate;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import persistence.entity.EntityEntry;
+import persistence.entity.JdbcEntityEntry;
 import persistence.entity.JdbcPersistenceContext;
 import persistence.entity.PersistenceContext;
 import persistence.meta.MetaEntity;
@@ -28,6 +29,7 @@ public class BuilderTest {
   public static SelectQueryBuilder selectQueryBuilder;
   public static Connection connection;
   public static PersistenceContext persistenceContext;
+  public static EntityEntry entityEntry;
 
   @BeforeAll
   static void setup() throws SQLException {
@@ -38,7 +40,7 @@ public class BuilderTest {
     server.start();
     connection = server.getConnection();
     jdbcTemplate = new JdbcTemplate(connection);
-
+    entityEntry = new JdbcEntityEntry();
     insertQueryBuilder = new InsertQueryBuilder();
     createQueryBuilder = new CreateQueryBuilder();
     selectQueryBuilder = new SelectQueryBuilder();

--- a/src/test/java/util/CloneUtilsTest.java
+++ b/src/test/java/util/CloneUtilsTest.java
@@ -1,0 +1,29 @@
+package util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import persistence.sql.fixture.PersonFixtureStep3;
+import persistence.sql.fixture.PersonInstances;
+
+public class CloneUtilsTest {
+
+  private static Class<PersonFixtureStep3> clazz;
+
+  @BeforeAll
+  static void setup() {clazz = PersonFixtureStep3.class;
+  }
+
+  @Test
+  @DisplayName("deep copy 된 object와 car class는 동일하지 않고 동등합니다.")
+  void showCloneNotSameObject() {
+    PersonFixtureStep3 user = (PersonFixtureStep3) CloneUtils.clone(PersonInstances.두번째사람);
+
+    assertThat(user).isEqualTo(PersonInstances.두번째사람);
+    assertThat(user == PersonInstances.두번째사람).isFalse();
+  }
+}


### PR DESCRIPTION
정완님, 리뷰 잘해주셔서 정말 감사합니다! 배울게 많았습니다!
마지막으로 개발을 진행하면서 정신없이 진행했네요..

감사합니다!~


# 요구사항 1 상태에 따른 엔티티 상태 추가하기

feature(EntityEntry): putPersistenceContext 생성
1. LOADING -> MANAGED
2. SAVING -> MANAGED
3. DELETED -> GONE
4. READONLY?? -> DirtyChecking 만 안하면 될것같다.
   readonly 값을 em에서 받아야되는데 해당 부분을 어디서 구현해야할지 모르겠다.

**구현사항**

- CRUD 작업 수행시에 엔티티 상태를 추가하기

- EntityEntry 객체 설계 hibernate EntityEntryContext 참조 -> nextstep 그림보고 entityManager에 넣었다가 context로 삽입 
  PersistenceContext
    EntityEntry

  persistenceContext에서 바뀔때 entry에서도 상태 바꾸자
  - entry는 hashcode를 보고 동일성 판단한다.
  - <Integer, status>

- Saving 상태
  - Cache에 있음
  - snapshot에 없음
  - DB에 없음

- Managed 상태
  - Cache에 있음
  - Snapshot 있음
  - DB 에 있음

- READ_ONLY 상태
  - 변경내용 persist 되지 않음

- DELETED 상태 (GONE 전 상태)
  - Cache에 있어도 됨 
  - 더티체크시에 무시
  - Snapshot 있음
  - DB에 있음

- GONE 상태
  - Cache에 없음
  - Snapshot에 없음
  - DB에서 삭제됨

- LOADING 상태 (FIND 중)
  - Cache에 있음
  - Snapshot에 없음
  - DB에서 로드가 아직 안됨 (db에는 값이 있음)

- SAVING 상태 (PERSIST 중)
    - Cache에 있음
    - snapshot에 없음
    - db에서 로드 되기 전

**코드 리뷰사항**
1. java 11 맞추기 -> 완료
2. 동일성 테스트 해주기
    a. getEntityManager
    b. entityManager.find
    c. persistence context.
3. scheduleUpdate --> sync 해주기 (일단 persist로 구현했습니다 persistAll 필요할듯)
4. 자연키 vs 인조키 --> db 체크해주기
5. transaction 끝날때(flush군아) sync 부를수있게 진행하기
6. SNAPSHOT 업데이트와 PERSIST는 묶었습니다! 알고보니 JPA 에서도 수정사항이 많으면 EntityManager를 사용하지 않고 바로 처리해버리네요!