### PR TITLE
3단계 - First Level Cache, Dirty Check

### DIFF
--- a/src/main/java/jdbc/JdbcTemplate.java
+++ b/src/main/java/jdbc/JdbcTemplate.java
@@ -6,7 +6,9 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class JdbcTemplate {
     private final Connection connection;
 
@@ -15,6 +17,7 @@ public class JdbcTemplate {
     }
 
     public void execute(final String sql) {
+        log.debug(sql);
         try (final Statement statement = connection.createStatement()) {
             statement.execute(sql);
         } catch (Exception e) {
@@ -23,6 +26,7 @@ public class JdbcTemplate {
     }
 
     public <T> T queryForObject(final String sql, final RowMapper<T> rowMapper) {
+        log.debug(sql);
         try (final ResultSet resultSet = connection.prepareStatement(sql).executeQuery()) {
             resultSet.next();
             return rowMapper.mapRow(resultSet);
@@ -32,6 +36,7 @@ public class JdbcTemplate {
     }
 
     public <T> List<T> query(final String sql, final RowMapper<T> rowMapper) {
+        log.debug(sql);
         try (final ResultSet resultSet = connection.prepareStatement(sql).executeQuery()) {
             final List<T> result = new ArrayList<>();
             while (resultSet.next()) {
@@ -45,6 +50,7 @@ public class JdbcTemplate {
 
 
     public ResultSet query(final String sql) {
+        log.debug(sql);
         try {
             final ResultSet resultSet = connection.prepareStatement(sql).executeQuery();
             return resultSet;
@@ -54,6 +60,7 @@ public class JdbcTemplate {
     }
 
     public Long insertSingle(final String sql) {
+        log.debug(sql);
         try {
             final PreparedStatement preparedStatement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
             preparedStatement.executeUpdate();

--- a/src/main/java/persistence/entity/EntityManager.java
+++ b/src/main/java/persistence/entity/EntityManager.java
@@ -7,4 +7,6 @@ public interface EntityManager {
     <T> T persist(T entity);
 
     <T> void remove(T entity);
+
+    void clear();
 }

--- a/src/main/java/persistence/entity/EntityManager.java
+++ b/src/main/java/persistence/entity/EntityManager.java
@@ -4,7 +4,7 @@ public interface EntityManager {
 
     <T> T find(Class<T> clazz, Long Id);
 
-    Object persist(Object entity);
+    <T> T persist(T entity);
 
-    void remove(Object entity);
+    <T> void remove(T entity);
 }

--- a/src/main/java/persistence/entity/EntityManagerImpl.java
+++ b/src/main/java/persistence/entity/EntityManagerImpl.java
@@ -5,9 +5,9 @@ import persistence.entity.context.PersistenceContextImpl;
 import persistence.entity.loader.EntityLoader;
 import persistence.entity.persister.EntityPersister;
 import persistence.sql.usecase.CreateSnapShotObject;
-import persistence.sql.usecase.GetFieldValueUseCase;
+import persistence.sql.usecase.GetFieldValue;
 import persistence.sql.usecase.GetIdDatabaseFieldUseCase;
-import persistence.sql.usecase.SetFieldValueUseCase;
+import persistence.sql.usecase.SetFieldValue;
 import persistence.sql.vo.DatabaseField;
 
 import java.util.Map;
@@ -18,22 +18,22 @@ public class EntityManagerImpl implements EntityManager {
     private final EntityLoader entityLoader;
     private final EntityPersister entityPersister;
     private final GetIdDatabaseFieldUseCase getIdDatabaseFieldUseCase;
-    private final GetFieldValueUseCase getFieldValueUseCase;
-    private final SetFieldValueUseCase setFieldValueUseCase;
+    private final GetFieldValue getFieldValue;
+    private final SetFieldValue setFieldValue;
     private final CreateSnapShotObject createSnapShotObject;
     private final Map<Class<?>, PersistenceContext<?>> persistenceContextMap = new ConcurrentHashMap<>();
 
 
     public EntityManagerImpl(EntityLoader entityLoader, EntityPersister entityPersister,
                              GetIdDatabaseFieldUseCase getIdDatabaseFieldUseCase,
-                             GetFieldValueUseCase getFieldValueUseCase,
-                             SetFieldValueUseCase setFieldValueUseCase,
+                             GetFieldValue getFieldValue,
+                             SetFieldValue setFieldValue,
                              CreateSnapShotObject createSnapShotObject) {
         this.entityLoader = entityLoader;
         this.entityPersister = entityPersister;
         this.getIdDatabaseFieldUseCase = getIdDatabaseFieldUseCase;
-        this.getFieldValueUseCase = getFieldValueUseCase;
-        this.setFieldValueUseCase = setFieldValueUseCase;
+        this.getFieldValue = getFieldValue;
+        this.setFieldValue = setFieldValue;
         this.createSnapShotObject = createSnapShotObject;
     }
 
@@ -56,7 +56,7 @@ public class EntityManagerImpl implements EntityManager {
 
     @Override
     public <T> T persist(T entity) {
-        Object idValue = getFieldValueUseCase.execute(entity, getIdDatabaseFieldUseCase.execute(entity.getClass()));
+        Object idValue = getFieldValue.execute(entity, getIdDatabaseFieldUseCase.execute(entity.getClass()));
         if (idValue == null) {
             return insertIfNotExist(entity);
         }
@@ -92,7 +92,7 @@ public class EntityManagerImpl implements EntityManager {
         if (persistenceContextMap.containsKey(cls)) {
             return (PersistenceContext<T>) persistenceContextMap.get(cls);
         }
-        PersistenceContext<T> newContext = new PersistenceContextImpl<T>(getIdDatabaseFieldUseCase, getFieldValueUseCase, createSnapShotObject);
+        PersistenceContext<T> newContext = new PersistenceContextImpl<T>(getIdDatabaseFieldUseCase, getFieldValue, createSnapShotObject);
         persistenceContextMap.put(cls, newContext);
         return newContext;
     }
@@ -112,7 +112,7 @@ public class EntityManagerImpl implements EntityManager {
         Long id = entityPersister.insert(entity);
         PersistenceContext<T> persistenceContext = getPersistenceContext((Class<T>) entity.getClass());
         DatabaseField databaseField = getIdDatabaseFieldUseCase.execute(entity.getClass());
-        setFieldValueUseCase.execute(entity, databaseField, id);
+        setFieldValue.execute(entity, databaseField, id);
         persistenceContext.addEntity(id, entity);
         return entity;
     }

--- a/src/main/java/persistence/entity/EntityManagerImpl.java
+++ b/src/main/java/persistence/entity/EntityManagerImpl.java
@@ -13,7 +13,6 @@ public class EntityManagerImpl implements EntityManager {
     private final EntityPersister entityPersister;
     private final GetIdDatabaseFieldUseCase getIdDatabaseFieldUseCase;
     private final GetFieldValueUseCase getFieldValueUseCase;
-
     private final SetFieldValueUseCase setFieldValueUseCase;
 
 

--- a/src/main/java/persistence/entity/EntityManagerImpl.java
+++ b/src/main/java/persistence/entity/EntityManagerImpl.java
@@ -100,6 +100,7 @@ public class EntityManagerImpl implements EntityManager {
         DatabaseField databaseField = getIdDatabaseFieldUseCase.execute(entity.getClass());
         setFieldValueUseCase.execute(entity, databaseField, id);
         persistenceContext.addEntity(id, entity);
+        persistenceContext.addDatabaseSnapshot(id, entity);
         return entity;
     }
 }

--- a/src/main/java/persistence/entity/EntityManagerImpl.java
+++ b/src/main/java/persistence/entity/EntityManagerImpl.java
@@ -1,11 +1,16 @@
 package persistence.entity;
 
+import persistence.entity.context.PersistenceContext;
+import persistence.entity.context.PersistenceContextImpl;
 import persistence.entity.loader.EntityLoader;
 import persistence.entity.persister.EntityPersister;
 import persistence.sql.usecase.GetFieldValueUseCase;
 import persistence.sql.usecase.GetIdDatabaseFieldUseCase;
 import persistence.sql.usecase.SetFieldValueUseCase;
 import persistence.sql.vo.DatabaseField;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class EntityManagerImpl implements EntityManager {
 
@@ -14,6 +19,7 @@ public class EntityManagerImpl implements EntityManager {
     private final GetIdDatabaseFieldUseCase getIdDatabaseFieldUseCase;
     private final GetFieldValueUseCase getFieldValueUseCase;
     private final SetFieldValueUseCase setFieldValueUseCase;
+    private final Map<Class<?>, PersistenceContext<?>> persistenceContextMap = new ConcurrentHashMap<>();
 
 
     public EntityManagerImpl(EntityLoader entityLoader, EntityPersister entityPersister,
@@ -29,24 +35,53 @@ public class EntityManagerImpl implements EntityManager {
 
     @Override
     public <T> T find(Class<T> clazz, Long Id) {
-        return entityLoader.find(clazz, Id);
-    }
-
-    @Override
-    public Object persist(Object entity) {
-        Object idValue = getFieldValueUseCase.execute(entity, getIdDatabaseFieldUseCase.execute(entity.getClass()));
-        if (idValue != null) {
-            entityPersister.update(entity);
-            return entity;
+        T entity = entityLoader.find(clazz, Id);
+        if(entity != null) {
+            PersistenceContext<T> persistenceContext = getPersistenceContext(clazz);
+            persistenceContext.addEntity(Id, entity);
         }
-        Long id = entityPersister.insert(entity);
-        DatabaseField databaseField = getIdDatabaseFieldUseCase.execute(entity.getClass());
-        setFieldValueUseCase.execute(entity, databaseField, id);
         return entity;
     }
 
     @Override
-    public void remove(Object entity) {
+    public <T> T persist(T entity) {
+        Object idValue = getFieldValueUseCase.execute(entity, getIdDatabaseFieldUseCase.execute(entity.getClass()));
+        PersistenceContext<T> persistenceContext = getPersistenceContext((Class<T>) entity.getClass());
+        // id가 있는 경우
+        if (idValue != null) {
+            T findEntity = (T) find(entity.getClass(), (Long) idValue);
+            if(findEntity == null) { // 키를 가지고 넣어주는 경우
+                entityPersister.insert(entity);
+                persistenceContext.addEntity((Long) idValue, entity);
+                return entity;
+            } else { // 이미 존재하는 데이터
+                entityPersister.update(entity);
+                persistenceContext.addEntity((Long) idValue, entity);
+                return findEntity;
+            }
+        }
+        // id가 없는 경우
+        Long id = entityPersister.insert(entity);
+        DatabaseField databaseField = getIdDatabaseFieldUseCase.execute(entity.getClass());
+        setFieldValueUseCase.execute(entity, databaseField, id);
+        persistenceContext.addEntity(id, entity);
+        return entity;
+    }
+
+    @Override
+    public <T> void remove(T entity) {
+        Class<T> cls = (Class<T>) entity.getClass();
+        PersistenceContext<T> persistenceContext = getPersistenceContext(cls);
+        persistenceContext.removeEntity(entity);
         entityPersister.delete(entity);
+    }
+
+    private <T> PersistenceContext<T> getPersistenceContext(Class<T> cls) {
+        if(persistenceContextMap.containsKey(cls)) {
+            return (PersistenceContext<T>) persistenceContextMap.get(cls);
+        }
+        PersistenceContext<T> newContext = new PersistenceContextImpl<T>(getIdDatabaseFieldUseCase, getFieldValueUseCase);
+        persistenceContextMap.put(cls, newContext);
+        return newContext;
     }
 }

--- a/src/main/java/persistence/entity/EntityManagerImpl.java
+++ b/src/main/java/persistence/entity/EntityManagerImpl.java
@@ -2,6 +2,7 @@ package persistence.entity;
 
 import persistence.entity.context.PersistenceContext;
 import persistence.entity.context.PersistenceContextImpl;
+import persistence.entity.context.PersistenceContextMap;
 import persistence.entity.loader.EntityLoader;
 import persistence.entity.persister.EntityPersister;
 import persistence.sql.usecase.CreateSnapShotObject;
@@ -9,9 +10,6 @@ import persistence.sql.usecase.GetFieldValue;
 import persistence.sql.usecase.GetIdDatabaseFieldUseCase;
 import persistence.sql.usecase.SetFieldValue;
 import persistence.sql.vo.DatabaseField;
-
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class EntityManagerImpl implements EntityManager {
 
@@ -21,16 +19,18 @@ public class EntityManagerImpl implements EntityManager {
     private final GetFieldValue getFieldValue;
     private final SetFieldValue setFieldValue;
     private final CreateSnapShotObject createSnapShotObject;
-    private final Map<Class<?>, PersistenceContext<?>> persistenceContextMap = new ConcurrentHashMap<>();
+    private final PersistenceContextMap persistenceContextMap;
 
 
     public EntityManagerImpl(EntityLoader entityLoader, EntityPersister entityPersister,
+                             PersistenceContextMap persistenceContextMap,
                              GetIdDatabaseFieldUseCase getIdDatabaseFieldUseCase,
                              GetFieldValue getFieldValue,
                              SetFieldValue setFieldValue,
                              CreateSnapShotObject createSnapShotObject) {
         this.entityLoader = entityLoader;
         this.entityPersister = entityPersister;
+        this.persistenceContextMap = persistenceContextMap;
         this.getIdDatabaseFieldUseCase = getIdDatabaseFieldUseCase;
         this.getFieldValue = getFieldValue;
         this.setFieldValue = setFieldValue;
@@ -80,11 +80,6 @@ public class EntityManagerImpl implements EntityManager {
 
     @Override
     public void clear() {
-        persistenceContextMap.forEach(
-            (key, value) -> {
-                value.clear();
-            }
-        );
         persistenceContextMap.clear();
     }
 

--- a/src/main/java/persistence/entity/EntityManagerImpl.java
+++ b/src/main/java/persistence/entity/EntityManagerImpl.java
@@ -46,7 +46,6 @@ public class EntityManagerImpl implements EntityManager {
         T entity = entityLoader.find(clazz, Id);
         if (entity != null) {
             persistenceContext.addEntity(Id, entity);
-            persistenceContext.addDatabaseSnapshot(Id, entity);
         }
         return entity;
     }
@@ -91,6 +90,7 @@ public class EntityManagerImpl implements EntityManager {
             return entity;
         }
         entityPersister.update(entity);
+        persistenceContext.addEntity(idValue, entity);
         return entity;
     }
 
@@ -100,7 +100,6 @@ public class EntityManagerImpl implements EntityManager {
         DatabaseField databaseField = getIdDatabaseFieldUseCase.execute(entity.getClass());
         setFieldValueUseCase.execute(entity, databaseField, id);
         persistenceContext.addEntity(id, entity);
-        persistenceContext.addDatabaseSnapshot(id, entity);
         return entity;
     }
 }

--- a/src/main/java/persistence/entity/EntityManagerImpl.java
+++ b/src/main/java/persistence/entity/EntityManagerImpl.java
@@ -46,7 +46,7 @@ public class EntityManagerImpl implements EntityManager {
         T entity = entityLoader.find(clazz, Id);
         if (entity != null) {
             persistenceContext.addEntity(Id, entity);
-            persistenceContext.getDatabaseSnapshot(Id, entity);
+            persistenceContext.addDatabaseSnapshot(Id, entity);
         }
         return entity;
     }
@@ -60,9 +60,10 @@ public class EntityManagerImpl implements EntityManager {
         T findEntity = (T) find(entity.getClass(), (Long) idValue);
         if (findEntity == null) {
             return insertIfNotExist(entity);
-        } else {
-            return updatetIfAlreadyExist(entity, (Long) idValue);
         }
+
+        return updatetIfAlreadyExist(entity, (Long) idValue);
+
     }
 
 
@@ -84,9 +85,12 @@ public class EntityManagerImpl implements EntityManager {
     }
 
     private <T> T updatetIfAlreadyExist(T entity, Long idValue) {
-        entityPersister.update(entity);
         PersistenceContext<T> persistenceContext = getPersistenceContext((Class<T>) entity.getClass());
-        persistenceContext.addEntity(idValue, entity);
+        T snapshotEntity = persistenceContext.getDatabaseSnapshot(idValue);
+        if (entity.equals(snapshotEntity)) {
+            return entity;
+        }
+        entityPersister.update(entity);
         return entity;
     }
 

--- a/src/main/java/persistence/entity/Person.java
+++ b/src/main/java/persistence/entity/Person.java
@@ -62,4 +62,8 @@ public class Person {
     public void setId(Long id) {
         this.id = id;
     }
+
+    public void updateEmail(String email) {
+        this.email = email;
+    }
 }

--- a/src/main/java/persistence/entity/Person.java
+++ b/src/main/java/persistence/entity/Person.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import java.util.Objects;
 import lombok.ToString;
 
 @ToString
@@ -65,5 +66,23 @@ public class Person {
 
     public void updateEmail(String email) {
         this.email = email;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        Person person = (Person) object;
+        return Objects.equals(id, person.id) && Objects.equals(name, person.name) && Objects.equals(age, person.age) && Objects.equals(email, person.email)
+            && Objects.equals(index, person.index);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, age, email, index);
     }
 }

--- a/src/main/java/persistence/entity/context/PersistenceContext.java
+++ b/src/main/java/persistence/entity/context/PersistenceContext.java
@@ -9,4 +9,6 @@ public interface PersistenceContext<T> {
     void removeEntity(T entity);
 
     T getDatabaseSnapshot(Long id);
+
+    void clear();
 }

--- a/src/main/java/persistence/entity/context/PersistenceContext.java
+++ b/src/main/java/persistence/entity/context/PersistenceContext.java
@@ -9,5 +9,4 @@ public interface PersistenceContext<T> {
     void removeEntity(T entity);
 
     T getDatabaseSnapshot(Long id);
-    void addDatabaseSnapshot(Long id, T entity);
 }

--- a/src/main/java/persistence/entity/context/PersistenceContext.java
+++ b/src/main/java/persistence/entity/context/PersistenceContext.java
@@ -1,0 +1,10 @@
+package persistence.entity.context;
+
+public interface PersistenceContext {
+
+    Object getEntity(Long id);
+
+    void addEntity(Long id, Object entity);
+
+    void removeEntity(Object entity);
+}

--- a/src/main/java/persistence/entity/context/PersistenceContext.java
+++ b/src/main/java/persistence/entity/context/PersistenceContext.java
@@ -8,5 +8,6 @@ public interface PersistenceContext<T> {
 
     void removeEntity(T entity);
 
-    T getDatabaseSnapshot(Long id, T entity);
+    T getDatabaseSnapshot(Long id);
+    void addDatabaseSnapshot(Long id, T entity);
 }

--- a/src/main/java/persistence/entity/context/PersistenceContext.java
+++ b/src/main/java/persistence/entity/context/PersistenceContext.java
@@ -1,10 +1,10 @@
 package persistence.entity.context;
 
-public interface PersistenceContext {
+public interface PersistenceContext<T> {
 
     Object getEntity(Long id);
 
-    void addEntity(Long id, Object entity);
+    void addEntity(Long id, T entity);
 
-    void removeEntity(Object entity);
+    void removeEntity(T entity);
 }

--- a/src/main/java/persistence/entity/context/PersistenceContext.java
+++ b/src/main/java/persistence/entity/context/PersistenceContext.java
@@ -7,4 +7,6 @@ public interface PersistenceContext<T> {
     void addEntity(Long id, T entity);
 
     void removeEntity(T entity);
+
+    T getDatabaseSnapshot(Long id, T entity);
 }

--- a/src/main/java/persistence/entity/context/PersistenceContext.java
+++ b/src/main/java/persistence/entity/context/PersistenceContext.java
@@ -2,7 +2,7 @@ package persistence.entity.context;
 
 public interface PersistenceContext<T> {
 
-    Object getEntity(Long id);
+    T getEntity(Long id);
 
     void addEntity(Long id, T entity);
 

--- a/src/main/java/persistence/entity/context/PersistenceContextImpl.java
+++ b/src/main/java/persistence/entity/context/PersistenceContextImpl.java
@@ -1,0 +1,35 @@
+package persistence.entity.context;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import persistence.sql.usecase.GetFieldValueUseCase;
+import persistence.sql.usecase.GetIdDatabaseFieldUseCase;
+import persistence.sql.vo.DatabaseField;
+
+public class PersistenceContextImpl<T> implements PersistenceContext {
+    private final Map<Long, T> context = new ConcurrentHashMap<>();
+    private final GetIdDatabaseFieldUseCase getIdDatabaseFieldUseCase;
+    private final GetFieldValueUseCase getFieldValueUseCase;
+
+    public PersistenceContextImpl(GetIdDatabaseFieldUseCase getIdDatabaseFieldUseCase, GetFieldValueUseCase getFieldValueUseCase) {
+        this.getIdDatabaseFieldUseCase = getIdDatabaseFieldUseCase;
+        this.getFieldValueUseCase = getFieldValueUseCase;
+    }
+
+    @Override
+    public Object getEntity(Long id) {
+        return context.get(id);
+    }
+
+    @Override
+    public void addEntity(Long id, Object entity) {
+        context.put(id, (T) entity);
+    }
+
+    @Override
+    public void removeEntity(Object entity) {
+        DatabaseField databaseField = getIdDatabaseFieldUseCase.execute(entity.getClass());
+        Long id = (Long) getFieldValueUseCase.execute(entity, databaseField);
+        context.remove(id);
+    }
+}

--- a/src/main/java/persistence/entity/context/PersistenceContextImpl.java
+++ b/src/main/java/persistence/entity/context/PersistenceContextImpl.java
@@ -36,6 +36,7 @@ public class PersistenceContextImpl<T> implements PersistenceContext<T> {
         DatabaseField databaseField = getIdDatabaseFieldUseCase.execute(entity.getClass());
         Long id = (Long) getFieldValueUseCase.execute(entity, databaseField);
         cache.remove(id);
+        snapShot.remove(id);
     }
 
     @Override

--- a/src/main/java/persistence/entity/context/PersistenceContextImpl.java
+++ b/src/main/java/persistence/entity/context/PersistenceContextImpl.java
@@ -3,7 +3,7 @@ package persistence.entity.context;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import persistence.sql.usecase.CreateSnapShotObject;
-import persistence.sql.usecase.GetFieldValueUseCase;
+import persistence.sql.usecase.GetFieldValue;
 import persistence.sql.usecase.GetIdDatabaseFieldUseCase;
 import persistence.sql.vo.DatabaseField;
 
@@ -11,12 +11,12 @@ public class PersistenceContextImpl<T> implements PersistenceContext<T> {
     private final Map<Long, T> cache = new ConcurrentHashMap<>();
     private final Map<Long, T> snapShot = new ConcurrentHashMap<>();
     private final GetIdDatabaseFieldUseCase getIdDatabaseFieldUseCase;
-    private final GetFieldValueUseCase getFieldValueUseCase;
+    private final GetFieldValue getFieldValue;
     private final CreateSnapShotObject createSnapShotObject;
 
-    public PersistenceContextImpl(GetIdDatabaseFieldUseCase getIdDatabaseFieldUseCase, GetFieldValueUseCase getFieldValueUseCase, CreateSnapShotObject createSnapShotObject) {
+    public PersistenceContextImpl(GetIdDatabaseFieldUseCase getIdDatabaseFieldUseCase, GetFieldValue getFieldValue, CreateSnapShotObject createSnapShotObject) {
         this.getIdDatabaseFieldUseCase = getIdDatabaseFieldUseCase;
-        this.getFieldValueUseCase = getFieldValueUseCase;
+        this.getFieldValue = getFieldValue;
         this.createSnapShotObject = createSnapShotObject;
     }
 
@@ -38,7 +38,7 @@ public class PersistenceContextImpl<T> implements PersistenceContext<T> {
     @Override
     public void removeEntity(T entity) {
         DatabaseField databaseField = getIdDatabaseFieldUseCase.execute(entity.getClass());
-        Long id = (Long) getFieldValueUseCase.execute(entity, databaseField);
+        Long id = (Long) getFieldValue.execute(entity, databaseField);
         cache.remove(id);
         snapShot.remove(id);
     }

--- a/src/main/java/persistence/entity/context/PersistenceContextImpl.java
+++ b/src/main/java/persistence/entity/context/PersistenceContextImpl.java
@@ -18,16 +18,20 @@ public class PersistenceContextImpl<T> implements PersistenceContext {
 
     @Override
     public Object getEntity(Long id) {
+        System.out.println("########### get " + context.get(id).toString());
         return context.get(id);
     }
 
+
     @Override
     public void addEntity(Long id, Object entity) {
+        System.out.println("########### add " + entity.toString());
         context.put(id, (T) entity);
     }
 
     @Override
     public void removeEntity(Object entity) {
+        System.out.println("########### remove " + entity);
         DatabaseField databaseField = getIdDatabaseFieldUseCase.execute(entity.getClass());
         Long id = (Long) getFieldValueUseCase.execute(entity, databaseField);
         context.remove(id);

--- a/src/main/java/persistence/entity/context/PersistenceContextImpl.java
+++ b/src/main/java/persistence/entity/context/PersistenceContextImpl.java
@@ -39,7 +39,12 @@ public class PersistenceContextImpl<T> implements PersistenceContext<T> {
     }
 
     @Override
-    public T getDatabaseSnapshot(Long id, T entity) {
-        return snapShot.put(id, entity);
+    public T getDatabaseSnapshot(Long id) {
+        return snapShot.get(id);
+    }
+
+    @Override
+    public void addDatabaseSnapshot(Long id, T entity) {
+        snapShot.put(id, entity);
     }
 }

--- a/src/main/java/persistence/entity/context/PersistenceContextImpl.java
+++ b/src/main/java/persistence/entity/context/PersistenceContextImpl.java
@@ -26,8 +26,12 @@ public class PersistenceContextImpl<T> implements PersistenceContext<T> {
 
     @Override
     public void addEntity(Long id, T entity) {
+        if (id == null || entity == null) {
+            return;
+        }
         System.out.println("########### add " + entity.toString());
         cache.put(id, entity);
+        snapShot.put(id, entity);
     }
 
     @Override
@@ -42,10 +46,5 @@ public class PersistenceContextImpl<T> implements PersistenceContext<T> {
     @Override
     public T getDatabaseSnapshot(Long id) {
         return snapShot.get(id);
-    }
-
-    @Override
-    public void addDatabaseSnapshot(Long id, T entity) {
-        snapShot.put(id, entity);
     }
 }

--- a/src/main/java/persistence/entity/context/PersistenceContextImpl.java
+++ b/src/main/java/persistence/entity/context/PersistenceContextImpl.java
@@ -2,6 +2,7 @@ package persistence.entity.context;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import persistence.sql.usecase.CreateSnapShotObject;
 import persistence.sql.usecase.GetFieldValueUseCase;
 import persistence.sql.usecase.GetIdDatabaseFieldUseCase;
 import persistence.sql.vo.DatabaseField;
@@ -11,15 +12,16 @@ public class PersistenceContextImpl<T> implements PersistenceContext<T> {
     private final Map<Long, T> snapShot = new ConcurrentHashMap<>();
     private final GetIdDatabaseFieldUseCase getIdDatabaseFieldUseCase;
     private final GetFieldValueUseCase getFieldValueUseCase;
+    private final CreateSnapShotObject createSnapShotObject;
 
-    public PersistenceContextImpl(GetIdDatabaseFieldUseCase getIdDatabaseFieldUseCase, GetFieldValueUseCase getFieldValueUseCase) {
+    public PersistenceContextImpl(GetIdDatabaseFieldUseCase getIdDatabaseFieldUseCase, GetFieldValueUseCase getFieldValueUseCase, CreateSnapShotObject createSnapShotObject) {
         this.getIdDatabaseFieldUseCase = getIdDatabaseFieldUseCase;
         this.getFieldValueUseCase = getFieldValueUseCase;
+        this.createSnapShotObject = createSnapShotObject;
     }
 
     @Override
     public T getEntity(Long id) {
-        System.out.println("########### get " + cache.get(id).toString());
         return cache.get(id);
     }
 
@@ -29,14 +31,12 @@ public class PersistenceContextImpl<T> implements PersistenceContext<T> {
         if (id == null || entity == null) {
             return;
         }
-        System.out.println("########### add " + entity.toString());
         cache.put(id, entity);
-        snapShot.put(id, entity);
+        snapShot.put(id, (T) createSnapShotObject.execute(entity));
     }
 
     @Override
     public void removeEntity(T entity) {
-        System.out.println("########### remove " + entity);
         DatabaseField databaseField = getIdDatabaseFieldUseCase.execute(entity.getClass());
         Long id = (Long) getFieldValueUseCase.execute(entity, databaseField);
         cache.remove(id);
@@ -46,5 +46,11 @@ public class PersistenceContextImpl<T> implements PersistenceContext<T> {
     @Override
     public T getDatabaseSnapshot(Long id) {
         return snapShot.get(id);
+    }
+
+    @Override
+    public void clear() {
+        cache.clear();
+        snapShot.clear();
     }
 }

--- a/src/main/java/persistence/entity/context/PersistenceContextImpl.java
+++ b/src/main/java/persistence/entity/context/PersistenceContextImpl.java
@@ -6,7 +6,7 @@ import persistence.sql.usecase.GetFieldValueUseCase;
 import persistence.sql.usecase.GetIdDatabaseFieldUseCase;
 import persistence.sql.vo.DatabaseField;
 
-public class PersistenceContextImpl<T> implements PersistenceContext {
+public class PersistenceContextImpl<T> implements PersistenceContext<T> {
     private final Map<Long, T> context = new ConcurrentHashMap<>();
     private final GetIdDatabaseFieldUseCase getIdDatabaseFieldUseCase;
     private final GetFieldValueUseCase getFieldValueUseCase;
@@ -17,20 +17,20 @@ public class PersistenceContextImpl<T> implements PersistenceContext {
     }
 
     @Override
-    public Object getEntity(Long id) {
+    public T getEntity(Long id) {
         System.out.println("########### get " + context.get(id).toString());
         return context.get(id);
     }
 
 
     @Override
-    public void addEntity(Long id, Object entity) {
+    public void addEntity(Long id, T entity) {
         System.out.println("########### add " + entity.toString());
-        context.put(id, (T) entity);
+        context.put(id, entity);
     }
 
     @Override
-    public void removeEntity(Object entity) {
+    public void removeEntity(T entity) {
         System.out.println("########### remove " + entity);
         DatabaseField databaseField = getIdDatabaseFieldUseCase.execute(entity.getClass());
         Long id = (Long) getFieldValueUseCase.execute(entity, databaseField);

--- a/src/main/java/persistence/entity/context/PersistenceContextImpl.java
+++ b/src/main/java/persistence/entity/context/PersistenceContextImpl.java
@@ -7,7 +7,8 @@ import persistence.sql.usecase.GetIdDatabaseFieldUseCase;
 import persistence.sql.vo.DatabaseField;
 
 public class PersistenceContextImpl<T> implements PersistenceContext<T> {
-    private final Map<Long, T> context = new ConcurrentHashMap<>();
+    private final Map<Long, T> cache = new ConcurrentHashMap<>();
+    private final Map<Long, T> snapShot = new ConcurrentHashMap<>();
     private final GetIdDatabaseFieldUseCase getIdDatabaseFieldUseCase;
     private final GetFieldValueUseCase getFieldValueUseCase;
 
@@ -18,15 +19,15 @@ public class PersistenceContextImpl<T> implements PersistenceContext<T> {
 
     @Override
     public T getEntity(Long id) {
-        System.out.println("########### get " + context.get(id).toString());
-        return context.get(id);
+        System.out.println("########### get " + cache.get(id).toString());
+        return cache.get(id);
     }
 
 
     @Override
     public void addEntity(Long id, T entity) {
         System.out.println("########### add " + entity.toString());
-        context.put(id, entity);
+        cache.put(id, entity);
     }
 
     @Override
@@ -34,6 +35,11 @@ public class PersistenceContextImpl<T> implements PersistenceContext<T> {
         System.out.println("########### remove " + entity);
         DatabaseField databaseField = getIdDatabaseFieldUseCase.execute(entity.getClass());
         Long id = (Long) getFieldValueUseCase.execute(entity, databaseField);
-        context.remove(id);
+        cache.remove(id);
+    }
+
+    @Override
+    public T getDatabaseSnapshot(Long id, T entity) {
+        return snapShot.put(id, entity);
     }
 }

--- a/src/main/java/persistence/entity/context/PersistenceContextMap.java
+++ b/src/main/java/persistence/entity/context/PersistenceContextMap.java
@@ -1,0 +1,27 @@
+package persistence.entity.context;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class PersistenceContextMap {
+    private final Map<Class<?>, PersistenceContext<?>> persistenceContextMap = new ConcurrentHashMap<>();
+
+    public PersistenceContext<?> get(Class<?> cls) {
+        return persistenceContextMap.get(cls);
+    }
+
+    public boolean containsKey(Class<?> cls) {
+        return this.persistenceContextMap.containsKey(cls);
+    }
+
+    public void put(Class<?> cls, PersistenceContext<?> persistenceContext) {
+        persistenceContextMap.put(cls, persistenceContext);
+    }
+
+    public void clear() {
+        persistenceContextMap.forEach((key, value) -> {
+            value.clear();
+        });
+        persistenceContextMap.clear();
+    }
+}

--- a/src/main/java/persistence/entity/loader/EntityLoader.java
+++ b/src/main/java/persistence/entity/loader/EntityLoader.java
@@ -4,8 +4,8 @@ import java.util.Collections;
 import jdbc.JdbcTemplate;
 import lombok.extern.slf4j.Slf4j;
 import persistence.sql.dml.assembler.DataManipulationLanguageAssembler;
-import persistence.sql.usecase.GetFieldFromClassUseCase;
-import persistence.sql.usecase.SetFieldValueUseCase;
+import persistence.sql.usecase.GetFieldFromClass;
+import persistence.sql.usecase.SetFieldValue;
 import persistence.sql.vo.DatabaseField;
 import persistence.sql.vo.DatabaseFields;
 import persistence.sql.vo.type.BigInt;
@@ -21,15 +21,15 @@ import java.util.List;
 
 @Slf4j
 public class EntityLoader {
-    private final GetFieldFromClassUseCase getFieldFromClassUseCase;
-    private final SetFieldValueUseCase setFieldValueUseCase;
+    private final GetFieldFromClass getFieldFromClass;
+    private final SetFieldValue setFieldValue;
     private final JdbcTemplate jdbcTemplate;
     private final DataManipulationLanguageAssembler dataManipulationLanguageAssembler;
 
-    public EntityLoader(GetFieldFromClassUseCase getFieldFromClassUseCase, SetFieldValueUseCase setFieldValueUseCase, JdbcTemplate jdbcTemplate,
+    public EntityLoader(GetFieldFromClass getFieldFromClass, SetFieldValue setFieldValue, JdbcTemplate jdbcTemplate,
                         DataManipulationLanguageAssembler dataManipulationLanguageAssembler) {
-        this.getFieldFromClassUseCase = getFieldFromClassUseCase;
-        this.setFieldValueUseCase = setFieldValueUseCase;
+        this.getFieldFromClass = getFieldFromClass;
+        this.setFieldValue = setFieldValue;
         this.jdbcTemplate = jdbcTemplate;
         this.dataManipulationLanguageAssembler = dataManipulationLanguageAssembler;
     }
@@ -49,7 +49,7 @@ public class EntityLoader {
         String sql = dataManipulationLanguageAssembler.generateSelectWithWhere(cls, id);
         List<T> entityList = new ArrayList<>();
         try (ResultSet resultSet = jdbcTemplate.query(sql)) {
-            DatabaseFields databaseFields = getFieldFromClassUseCase.execute(cls);
+            DatabaseFields databaseFields = getFieldFromClass.execute(cls);
             while (resultSet.next()) {
                 T entity = createInstance(cls);
                 entityList.add(fillEntityValue(entity, resultSet, databaseFields));
@@ -72,7 +72,7 @@ public class EntityLoader {
 
     private <T> T fillEntityValue(T object, ResultSet resultSet, DatabaseFields databaseFields) {
         for (DatabaseField databaseField : databaseFields.getDatabaseFields()) {
-            setFieldValueUseCase.execute(object, databaseField, getValueFromResultSet(databaseField, resultSet));
+            setFieldValue.execute(object, databaseField, getValueFromResultSet(databaseField, resultSet));
         }
         return object;
     }

--- a/src/main/java/persistence/entity/persister/EntityPersister.java
+++ b/src/main/java/persistence/entity/persister/EntityPersister.java
@@ -1,8 +1,10 @@
 package persistence.entity.persister;
 
 import jdbc.JdbcTemplate;
+import lombok.extern.slf4j.Slf4j;
 import persistence.sql.dml.assembler.DataManipulationLanguageAssembler;
 
+@Slf4j
 public class EntityPersister {
     private final DataManipulationLanguageAssembler dataManipulationLanguageAssembler;
     private final JdbcTemplate jdbcTemplate;
@@ -14,15 +16,18 @@ public class EntityPersister {
     }
 
     public boolean update(Object object) {
-        jdbcTemplate.execute(dataManipulationLanguageAssembler.generateUpdate(object));
+        String sql = dataManipulationLanguageAssembler.generateUpdate(object);
+        jdbcTemplate.execute(sql);
         return true;
     }
 
     public Long insert(Object object) {
-        return jdbcTemplate.insertSingle(dataManipulationLanguageAssembler.generateInsert(object));
+        String sql = dataManipulationLanguageAssembler.generateInsert(object);
+        return jdbcTemplate.insertSingle(sql);
     }
 
     public void delete(Object object) {
-        jdbcTemplate.execute(dataManipulationLanguageAssembler.generateDeleteWithWhere(object));
+        String sql = dataManipulationLanguageAssembler.generateDeleteWithWhere(object);
+        jdbcTemplate.execute(sql);
     }
 }

--- a/src/main/java/persistence/sql/ddl/DataDefinitionLanguageGenerator.java
+++ b/src/main/java/persistence/sql/ddl/DataDefinitionLanguageGenerator.java
@@ -1,27 +1,27 @@
 package persistence.sql.ddl;
 
-import persistence.sql.usecase.GetFieldFromClassUseCase;
-import persistence.sql.usecase.GetTableNameFromClassUseCase;
+import persistence.sql.usecase.GetFieldFromClass;
+import persistence.sql.usecase.GetTableNameFromClass;
 
 public class DataDefinitionLanguageGenerator {
-    private final GetTableNameFromClassUseCase getTableNameFromClassUseCase;
-    private final GetFieldFromClassUseCase getFieldFromClass;
+    private final GetTableNameFromClass getTableNameFromClass;
+    private final GetFieldFromClass getFieldFromClass;
 
 
-    public DataDefinitionLanguageGenerator(GetTableNameFromClassUseCase getTableNameFromClassUseCase,
-                                           GetFieldFromClassUseCase getFieldFromClass) {
-        this.getTableNameFromClassUseCase = getTableNameFromClassUseCase;
+    public DataDefinitionLanguageGenerator(GetTableNameFromClass getTableNameFromClass,
+                                           GetFieldFromClass getFieldFromClass) {
+        this.getTableNameFromClass = getTableNameFromClass;
         this.getFieldFromClass = getFieldFromClass;
     }
 
     public TableCreator generateTableCreatorWithClass(Class<?> dbClass) {
         return TableCreator.builder()
-                           .tableName(getTableNameFromClassUseCase.execute(dbClass))
+                           .tableName(getTableNameFromClass.execute(dbClass))
                            .fields(getFieldFromClass.execute(dbClass))
                            .build();
     }
 
     public TableRemover generateTableRemoverWithClass(Class<?> dbClass) {
-        return TableRemover.builder().tableName(getTableNameFromClassUseCase.execute(dbClass)).build();
+        return TableRemover.builder().tableName(getTableNameFromClass.execute(dbClass)).build();
     }
 }

--- a/src/main/java/persistence/sql/usecase/CreateSnapShotObject.java
+++ b/src/main/java/persistence/sql/usecase/CreateSnapShotObject.java
@@ -4,23 +4,23 @@ import java.lang.reflect.InvocationTargetException;
 import persistence.sql.vo.DatabaseFields;
 
 public class CreateSnapShotObject {
-    private final GetFieldFromClassUseCase getFieldFromClassUseCase;
-    private final GetFieldValueUseCase getFieldValueUseCase;
-    private final SetFieldValueUseCase setFieldValueUseCase;
+    private final GetFieldFromClass getFieldFromClass;
+    private final GetFieldValue getFieldValue;
+    private final SetFieldValue setFieldValue;
 
-    public CreateSnapShotObject(GetFieldFromClassUseCase getFieldFromClassUseCase, GetFieldValueUseCase getFieldValueUseCase, SetFieldValueUseCase setFieldValueUseCase) {
-        this.getFieldFromClassUseCase = getFieldFromClassUseCase;
-        this.getFieldValueUseCase = getFieldValueUseCase;
-        this.setFieldValueUseCase = setFieldValueUseCase;
+    public CreateSnapShotObject(GetFieldFromClass getFieldFromClass, GetFieldValue getFieldValue, SetFieldValue setFieldValue) {
+        this.getFieldFromClass = getFieldFromClass;
+        this.getFieldValue = getFieldValue;
+        this.setFieldValue = setFieldValue;
     }
 
     public Object execute(Object object) {
         Object newInstance = createInstance(object.getClass());
-        DatabaseFields databaseFields = getFieldFromClassUseCase.execute(object.getClass());
+        DatabaseFields databaseFields = getFieldFromClass.execute(object.getClass());
         databaseFields.getDatabaseFields().forEach(
             field -> {
-                Object value = getFieldValueUseCase.execute(object, field);
-                setFieldValueUseCase.execute(newInstance, field, value);
+                Object value = getFieldValue.execute(object, field);
+                setFieldValue.execute(newInstance, field, value);
             }
         );
         return newInstance;

--- a/src/main/java/persistence/sql/usecase/CreateSnapShotObject.java
+++ b/src/main/java/persistence/sql/usecase/CreateSnapShotObject.java
@@ -1,0 +1,36 @@
+package persistence.sql.usecase;
+
+import java.lang.reflect.InvocationTargetException;
+import persistence.sql.vo.DatabaseFields;
+
+public class CreateSnapShotObject {
+    private final GetFieldFromClassUseCase getFieldFromClassUseCase;
+    private final GetFieldValueUseCase getFieldValueUseCase;
+    private final SetFieldValueUseCase setFieldValueUseCase;
+
+    public CreateSnapShotObject(GetFieldFromClassUseCase getFieldFromClassUseCase, GetFieldValueUseCase getFieldValueUseCase, SetFieldValueUseCase setFieldValueUseCase) {
+        this.getFieldFromClassUseCase = getFieldFromClassUseCase;
+        this.getFieldValueUseCase = getFieldValueUseCase;
+        this.setFieldValueUseCase = setFieldValueUseCase;
+    }
+
+    public Object execute(Object object) {
+        Object newInstance = createInstance(object.getClass());
+        DatabaseFields databaseFields = getFieldFromClassUseCase.execute(object.getClass());
+        databaseFields.getDatabaseFields().forEach(
+            field -> {
+                Object value = getFieldValueUseCase.execute(object, field);
+                setFieldValueUseCase.execute(newInstance, field, value);
+            }
+        );
+        return newInstance;
+    }
+
+    private Object createInstance(Class<?> cls) {
+        try {
+            return cls.getDeclaredConstructor().newInstance();
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException("Can't create instance with class " + cls.getSimpleName());
+        }
+    }
+}

--- a/src/main/java/persistence/sql/usecase/GetFieldFromClass.java
+++ b/src/main/java/persistence/sql/usecase/GetFieldFromClass.java
@@ -12,7 +12,7 @@ import persistence.sql.vo.DatabaseField;
 import persistence.sql.vo.DatabaseFields;
 import persistence.sql.vo.type.TypeConverter;
 
-public class GetFieldFromClassUseCase {
+public class GetFieldFromClass {
     public DatabaseFields execute(Class<?> cls) {
         Field[] declaredFields = cls.getDeclaredFields();
         return DatabaseFields.of(Arrays.stream(declaredFields)

--- a/src/main/java/persistence/sql/usecase/GetFieldValue.java
+++ b/src/main/java/persistence/sql/usecase/GetFieldValue.java
@@ -3,7 +3,7 @@ package persistence.sql.usecase;
 import java.lang.reflect.Field;
 import persistence.sql.vo.DatabaseField;
 
-public class GetFieldValueUseCase {
+public class GetFieldValue {
 
     public Object execute(Object object, DatabaseField databaseField) {
         if(object == null) {

--- a/src/main/java/persistence/sql/usecase/GetIdDatabaseFieldUseCase.java
+++ b/src/main/java/persistence/sql/usecase/GetIdDatabaseFieldUseCase.java
@@ -7,14 +7,14 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class GetIdDatabaseFieldUseCase {
-    private final GetFieldFromClassUseCase getFieldFromClassUseCase;
+    private final GetFieldFromClass getFieldFromClass;
 
-    public GetIdDatabaseFieldUseCase(GetFieldFromClassUseCase getFieldFromClassUseCase) {
-        this.getFieldFromClassUseCase = getFieldFromClassUseCase;
+    public GetIdDatabaseFieldUseCase(GetFieldFromClass getFieldFromClass) {
+        this.getFieldFromClass = getFieldFromClass;
     }
 
     public DatabaseField execute(Class<?> cls) {
-        DatabaseFields databaseFields = getFieldFromClassUseCase.execute(cls);
+        DatabaseFields databaseFields = getFieldFromClass.execute(cls);
         List<DatabaseField> primaryFields = databaseFields.getDatabaseFields().stream().filter(DatabaseField::isPrimary).collect(Collectors.toList());
         if (primaryFields.size() != 1) {
             throw new RuntimeException("Id should be only one");

--- a/src/main/java/persistence/sql/usecase/GetTableNameFromClass.java
+++ b/src/main/java/persistence/sql/usecase/GetTableNameFromClass.java
@@ -5,7 +5,7 @@ import jakarta.persistence.Table;
 import persistence.sql.ddl.exception.CannotCreateTableException;
 import persistence.sql.vo.TableName;
 
-public class GetTableNameFromClassUseCase {
+public class GetTableNameFromClass {
     public TableName execute(Class<?> cls) {
         if (!cls.isAnnotationPresent(Entity.class)) {
             throw new CannotCreateTableException("Class is not annotated with @Entity");

--- a/src/main/java/persistence/sql/usecase/SetFieldValue.java
+++ b/src/main/java/persistence/sql/usecase/SetFieldValue.java
@@ -4,7 +4,7 @@ import persistence.sql.vo.DatabaseField;
 
 import java.lang.reflect.Field;
 
-public class SetFieldValueUseCase {
+public class SetFieldValue {
     public void execute(Object object, DatabaseField databaseField, Object value) {
         if(object == null) {
             throw new NullPointerException("object should not be null");

--- a/src/main/java/repository/CustomJpaRepository.java
+++ b/src/main/java/repository/CustomJpaRepository.java
@@ -1,0 +1,15 @@
+package repository;
+
+import persistence.entity.EntityManager;
+
+public class CustomJpaRepository<T, ID> {
+    private final EntityManager entityManager;
+
+    public CustomJpaRepository(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    public T save(T t) {
+        return entityManager.persist(t);
+    }
+}

--- a/src/test/java/persistence/TestUtils.java
+++ b/src/test/java/persistence/TestUtils.java
@@ -5,22 +5,22 @@ import persistence.sql.ddl.assembler.DataDefinitionLanguageAssembler;
 import persistence.sql.dialect.H2Dialect;
 import persistence.sql.dml.DataManipulationLanguageGenerator;
 import persistence.sql.dml.assembler.DataManipulationLanguageAssembler;
-import persistence.sql.usecase.GetFieldFromClassUseCase;
-import persistence.sql.usecase.GetFieldValueUseCase;
+import persistence.sql.usecase.GetFieldFromClass;
+import persistence.sql.usecase.GetFieldValue;
 import persistence.sql.usecase.GetIdDatabaseFieldUseCase;
-import persistence.sql.usecase.GetTableNameFromClassUseCase;
+import persistence.sql.usecase.GetTableNameFromClass;
 
 public class TestUtils {
     public static DataManipulationLanguageAssembler createDataManipulationLanguageAssembler() {
         H2Dialect h2Dialect = new H2Dialect();
-        GetTableNameFromClassUseCase getTableNameFromClassUseCase = new GetTableNameFromClassUseCase();
-        GetFieldFromClassUseCase getFieldFromClassUseCase = new GetFieldFromClassUseCase();
-        GetFieldValueUseCase getFieldValueUseCase = new GetFieldValueUseCase();
-        GetIdDatabaseFieldUseCase getIdDatabaseFieldUseCase = new GetIdDatabaseFieldUseCase(getFieldFromClassUseCase);
+        GetTableNameFromClass getTableNameFromClass = new GetTableNameFromClass();
+        GetFieldFromClass getFieldFromClass = new GetFieldFromClass();
+        GetFieldValue getFieldValue = new GetFieldValue();
+        GetIdDatabaseFieldUseCase getIdDatabaseFieldUseCase = new GetIdDatabaseFieldUseCase(getFieldFromClass);
         DataManipulationLanguageGenerator dataManipulationLanguageGenerator = new DataManipulationLanguageGenerator(
-            getTableNameFromClassUseCase,
-            getFieldFromClassUseCase,
-            getFieldValueUseCase,
+            getTableNameFromClass,
+            getFieldFromClass,
+            getFieldValue,
             getIdDatabaseFieldUseCase);
         return new DataManipulationLanguageAssembler(
             h2Dialect, dataManipulationLanguageGenerator
@@ -28,10 +28,10 @@ public class TestUtils {
     }
 
     public static DataDefinitionLanguageAssembler createDataDefinitionLanguageAssembler() {
-        GetTableNameFromClassUseCase getTableNameFromClassUseCase = new GetTableNameFromClassUseCase();
-        GetFieldFromClassUseCase getFieldFromClassUseCase = new GetFieldFromClassUseCase();
+        GetTableNameFromClass getTableNameFromClass = new GetTableNameFromClass();
+        GetFieldFromClass getFieldFromClass = new GetFieldFromClass();
         DataDefinitionLanguageGenerator dataDefinitionLanguageGenerator = new DataDefinitionLanguageGenerator(
-            getTableNameFromClassUseCase, getFieldFromClassUseCase
+            getTableNameFromClass, getFieldFromClass
         );
         return new DataDefinitionLanguageAssembler(dataDefinitionLanguageGenerator);
     }

--- a/src/test/java/persistence/entity/EntityManagerTest.java
+++ b/src/test/java/persistence/entity/EntityManagerTest.java
@@ -17,10 +17,10 @@ import persistence.entity.persister.EntityPersister;
 import persistence.sql.ddl.assembler.DataDefinitionLanguageAssembler;
 import persistence.sql.dml.assembler.DataManipulationLanguageAssembler;
 import persistence.sql.usecase.CreateSnapShotObject;
-import persistence.sql.usecase.GetFieldFromClassUseCase;
-import persistence.sql.usecase.GetFieldValueUseCase;
+import persistence.sql.usecase.GetFieldFromClass;
+import persistence.sql.usecase.GetFieldValue;
 import persistence.sql.usecase.GetIdDatabaseFieldUseCase;
-import persistence.sql.usecase.SetFieldValueUseCase;
+import persistence.sql.usecase.SetFieldValue;
 
 class EntityManagerTest {
     private final DataManipulationLanguageAssembler dataManipulationLanguageAssembler = createDataManipulationLanguageAssembler();
@@ -38,13 +38,13 @@ class EntityManagerTest {
         server.start();
         jdbcTemplate = new JdbcTemplate(server.getConnection());
         entityPersister = new EntityPersister(dataManipulationLanguageAssembler, jdbcTemplate);
-        entityLoader = new EntityLoader(new GetFieldFromClassUseCase(), new SetFieldValueUseCase(), jdbcTemplate, dataManipulationLanguageAssembler);
+        entityLoader = new EntityLoader(new GetFieldFromClass(), new SetFieldValue(), jdbcTemplate, dataManipulationLanguageAssembler);
         entityManager = new EntityManagerImpl(entityLoader,
             entityPersister,
-            new GetIdDatabaseFieldUseCase(new GetFieldFromClassUseCase()),
-            new GetFieldValueUseCase(),
-            new SetFieldValueUseCase(),
-            new CreateSnapShotObject(new GetFieldFromClassUseCase(), new GetFieldValueUseCase(), new SetFieldValueUseCase())
+            new GetIdDatabaseFieldUseCase(new GetFieldFromClass()),
+            new GetFieldValue(),
+            new SetFieldValue(),
+            new CreateSnapShotObject(new GetFieldFromClass(), new GetFieldValue(), new SetFieldValue())
         );
         jdbcTemplate.execute(dataDefinitionLanguageAssembler.assembleCreateTableQuery(Person.class));
     }

--- a/src/test/java/persistence/entity/EntityManagerTest.java
+++ b/src/test/java/persistence/entity/EntityManagerTest.java
@@ -12,6 +12,7 @@ import jdbc.JdbcTemplate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import persistence.entity.context.PersistenceContextMap;
 import persistence.entity.loader.EntityLoader;
 import persistence.entity.persister.EntityPersister;
 import persistence.sql.ddl.assembler.DataDefinitionLanguageAssembler;
@@ -41,6 +42,7 @@ class EntityManagerTest {
         entityLoader = new EntityLoader(new GetFieldFromClass(), new SetFieldValue(), jdbcTemplate, dataManipulationLanguageAssembler);
         entityManager = new EntityManagerImpl(entityLoader,
             entityPersister,
+            new PersistenceContextMap(),
             new GetIdDatabaseFieldUseCase(new GetFieldFromClass()),
             new GetFieldValue(),
             new SetFieldValue(),

--- a/src/test/java/persistence/entity/EntityManagerTest.java
+++ b/src/test/java/persistence/entity/EntityManagerTest.java
@@ -66,7 +66,7 @@ class EntityManagerTest {
     @Test
     void persist() {
         // when, then
-        Person person = (Person) entityManager.persist(new Person("tongnamuu", 11, "tongnamuu@naver.com"));
+        Person person = entityManager.persist(new Person("tongnamuu", 11, "tongnamuu@naver.com"));
         assertAll(
             () -> assertThat(person.getId()).isEqualTo(1L),
             () -> assertThat(person.getName()).isEqualTo(person.getName()),

--- a/src/test/java/persistence/entity/EntityManagerTest.java
+++ b/src/test/java/persistence/entity/EntityManagerTest.java
@@ -16,6 +16,7 @@ import persistence.entity.loader.EntityLoader;
 import persistence.entity.persister.EntityPersister;
 import persistence.sql.ddl.assembler.DataDefinitionLanguageAssembler;
 import persistence.sql.dml.assembler.DataManipulationLanguageAssembler;
+import persistence.sql.usecase.CreateSnapShotObject;
 import persistence.sql.usecase.GetFieldFromClassUseCase;
 import persistence.sql.usecase.GetFieldValueUseCase;
 import persistence.sql.usecase.GetIdDatabaseFieldUseCase;
@@ -39,7 +40,12 @@ class EntityManagerTest {
         entityPersister = new EntityPersister(dataManipulationLanguageAssembler, jdbcTemplate);
         entityLoader = new EntityLoader(new GetFieldFromClassUseCase(), new SetFieldValueUseCase(), jdbcTemplate, dataManipulationLanguageAssembler);
         entityManager = new EntityManagerImpl(entityLoader,
-            entityPersister, new GetIdDatabaseFieldUseCase(new GetFieldFromClassUseCase()), new GetFieldValueUseCase(), new SetFieldValueUseCase());
+            entityPersister,
+            new GetIdDatabaseFieldUseCase(new GetFieldFromClassUseCase()),
+            new GetFieldValueUseCase(),
+            new SetFieldValueUseCase(),
+            new CreateSnapShotObject(new GetFieldFromClassUseCase(), new GetFieldValueUseCase(), new SetFieldValueUseCase())
+        );
         jdbcTemplate.execute(dataDefinitionLanguageAssembler.assembleCreateTableQuery(Person.class));
     }
 

--- a/src/test/java/persistence/entity/loader/EntityLoaderTest.java
+++ b/src/test/java/persistence/entity/loader/EntityLoaderTest.java
@@ -15,8 +15,8 @@ import persistence.TestUtils;
 import persistence.entity.Person;
 import persistence.sql.ddl.assembler.DataDefinitionLanguageAssembler;
 import persistence.sql.dml.assembler.DataManipulationLanguageAssembler;
-import persistence.sql.usecase.GetFieldFromClassUseCase;
-import persistence.sql.usecase.SetFieldValueUseCase;
+import persistence.sql.usecase.GetFieldFromClass;
+import persistence.sql.usecase.SetFieldValue;
 
 class EntityLoaderTest {
     private final DataManipulationLanguageAssembler dataManipulationLanguageAssembler = TestUtils.createDataManipulationLanguageAssembler();
@@ -32,8 +32,8 @@ class EntityLoaderTest {
         jdbcTemplate = new JdbcTemplate(server.getConnection());
         jdbcTemplate.execute(dataDefinitionLanguageAssembler.assembleCreateTableQuery(Person.class));
         entityLoader = new EntityLoader(
-            new GetFieldFromClassUseCase(),
-            new SetFieldValueUseCase(),
+            new GetFieldFromClass(),
+            new SetFieldValue(),
             jdbcTemplate,
             dataManipulationLanguageAssembler
         );

--- a/src/test/java/persistence/sql/ddl/DataDefinitionLanguageGeneratorTest.java
+++ b/src/test/java/persistence/sql/ddl/DataDefinitionLanguageGeneratorTest.java
@@ -17,18 +17,18 @@ import persistence.sql.cls.MultipleId;
 import persistence.sql.cls.NoEntity;
 import persistence.sql.ddl.exception.CannotCreateTableException;
 import persistence.sql.ddl.exception.FieldShouldHaveOnlyOnePrimaryKeyException;
-import persistence.sql.usecase.GetFieldFromClassUseCase;
-import persistence.sql.usecase.GetTableNameFromClassUseCase;
+import persistence.sql.usecase.GetFieldFromClass;
+import persistence.sql.usecase.GetTableNameFromClass;
 import persistence.sql.vo.DatabaseField;
 import persistence.sql.vo.type.BigInt;
 import persistence.sql.vo.type.Int;
 import persistence.sql.vo.type.VarChar;
 
 class DataDefinitionLanguageGeneratorTest {
-    private final GetTableNameFromClassUseCase getTableNameFromClassUseCase = new GetTableNameFromClassUseCase();
-    private final GetFieldFromClassUseCase getFieldFromClassUseCase = new GetFieldFromClassUseCase();
+    private final GetTableNameFromClass getTableNameFromClass = new GetTableNameFromClass();
+    private final GetFieldFromClass getFieldFromClass = new GetFieldFromClass();
     private final DataDefinitionLanguageGenerator dataDefinitionLanguageGenerator = new DataDefinitionLanguageGenerator(
-            getTableNameFromClassUseCase, getFieldFromClassUseCase
+        getTableNameFromClass, getFieldFromClass
     );
 
 

--- a/src/test/java/persistence/sql/dml/assembler/DataManipulationLanguageAssemblerH2Test.java
+++ b/src/test/java/persistence/sql/dml/assembler/DataManipulationLanguageAssemblerH2Test.java
@@ -7,10 +7,10 @@ import org.junit.jupiter.api.Test;
 import persistence.entity.Person;
 import persistence.sql.dialect.H2Dialect;
 import persistence.sql.dml.DataManipulationLanguageGenerator;
-import persistence.sql.usecase.GetFieldFromClassUseCase;
-import persistence.sql.usecase.GetFieldValueUseCase;
+import persistence.sql.usecase.GetFieldFromClass;
+import persistence.sql.usecase.GetFieldValue;
 import persistence.sql.usecase.GetIdDatabaseFieldUseCase;
-import persistence.sql.usecase.GetTableNameFromClassUseCase;
+import persistence.sql.usecase.GetTableNameFromClass;
 
 class DataManipulationLanguageAssemblerH2Test {
     private final DataManipulationLanguageAssembler dataManipulationLanguageAssembler = createDataManipulationLanguageAssembler();
@@ -83,14 +83,14 @@ class DataManipulationLanguageAssemblerH2Test {
 
     private DataManipulationLanguageAssembler createDataManipulationLanguageAssembler() {
         H2Dialect h2Dialect = new H2Dialect();
-        GetTableNameFromClassUseCase getTableNameFromClassUseCase = new GetTableNameFromClassUseCase();
-        GetFieldFromClassUseCase getFieldFromClassUseCase = new GetFieldFromClassUseCase();
-        GetFieldValueUseCase getFieldValueUseCase = new GetFieldValueUseCase();
-        GetIdDatabaseFieldUseCase getIdDatabaseFieldUseCase = new GetIdDatabaseFieldUseCase(getFieldFromClassUseCase);
+        GetTableNameFromClass getTableNameFromClass = new GetTableNameFromClass();
+        GetFieldFromClass getFieldFromClass = new GetFieldFromClass();
+        GetFieldValue getFieldValue = new GetFieldValue();
+        GetIdDatabaseFieldUseCase getIdDatabaseFieldUseCase = new GetIdDatabaseFieldUseCase(getFieldFromClass);
         DataManipulationLanguageGenerator dataManipulationLanguageGenerator = new DataManipulationLanguageGenerator(
-            getTableNameFromClassUseCase,
-            getFieldFromClassUseCase,
-            getFieldValueUseCase, getIdDatabaseFieldUseCase);
+            getTableNameFromClass,
+            getFieldFromClass,
+            getFieldValue, getIdDatabaseFieldUseCase);
         return new DataManipulationLanguageAssembler(
             h2Dialect, dataManipulationLanguageGenerator
         );

--- a/src/test/java/repository/CustomJpaRepositoryTest.java
+++ b/src/test/java/repository/CustomJpaRepositoryTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import persistence.entity.EntityManager;
 import persistence.entity.EntityManagerImpl;
 import persistence.entity.Person;
+import persistence.entity.context.PersistenceContextMap;
 import persistence.entity.loader.EntityLoader;
 import persistence.entity.persister.EntityPersister;
 import persistence.sql.ddl.assembler.DataDefinitionLanguageAssembler;
@@ -46,6 +47,7 @@ class CustomJpaRepositoryTest {
         entityLoader = new EntityLoader(new GetFieldFromClass(), new SetFieldValue(), jdbcTemplate, dataManipulationLanguageAssembler);
         entityManager = new EntityManagerImpl(entityLoader,
             entityPersister,
+            new PersistenceContextMap(),
             new GetIdDatabaseFieldUseCase(new GetFieldFromClass()),
             new GetFieldValue(),
             new SetFieldValue(),

--- a/src/test/java/repository/CustomJpaRepositoryTest.java
+++ b/src/test/java/repository/CustomJpaRepositoryTest.java
@@ -20,10 +20,10 @@ import persistence.entity.persister.EntityPersister;
 import persistence.sql.ddl.assembler.DataDefinitionLanguageAssembler;
 import persistence.sql.dml.assembler.DataManipulationLanguageAssembler;
 import persistence.sql.usecase.CreateSnapShotObject;
-import persistence.sql.usecase.GetFieldFromClassUseCase;
-import persistence.sql.usecase.GetFieldValueUseCase;
+import persistence.sql.usecase.GetFieldFromClass;
+import persistence.sql.usecase.GetFieldValue;
 import persistence.sql.usecase.GetIdDatabaseFieldUseCase;
-import persistence.sql.usecase.SetFieldValueUseCase;
+import persistence.sql.usecase.SetFieldValue;
 
 class CustomJpaRepositoryTest {
     private final DataManipulationLanguageAssembler dataManipulationLanguageAssembler = createDataManipulationLanguageAssembler();
@@ -42,13 +42,13 @@ class CustomJpaRepositoryTest {
         server.start();
         jdbcTemplate = new JdbcTemplate(server.getConnection());
         entityPersister = new EntityPersister(dataManipulationLanguageAssembler, jdbcTemplate);
-        entityLoader = new EntityLoader(new GetFieldFromClassUseCase(), new SetFieldValueUseCase(), jdbcTemplate, dataManipulationLanguageAssembler);
+        entityLoader = new EntityLoader(new GetFieldFromClass(), new SetFieldValue(), jdbcTemplate, dataManipulationLanguageAssembler);
         entityManager = new EntityManagerImpl(entityLoader,
             entityPersister,
-            new GetIdDatabaseFieldUseCase(new GetFieldFromClassUseCase()),
-            new GetFieldValueUseCase(),
-            new SetFieldValueUseCase(),
-            new CreateSnapShotObject(new GetFieldFromClassUseCase(), new GetFieldValueUseCase(), new SetFieldValueUseCase())
+            new GetIdDatabaseFieldUseCase(new GetFieldFromClass()),
+            new GetFieldValue(),
+            new SetFieldValue(),
+            new CreateSnapShotObject(new GetFieldFromClass(), new GetFieldValue(), new SetFieldValue())
         );
         jdbcTemplate.execute(dataDefinitionLanguageAssembler.assembleCreateTableQuery(Person.class));
         customJpaRepository = new CustomJpaRepository<>(entityManager);

--- a/src/test/java/repository/CustomJpaRepositoryTest.java
+++ b/src/test/java/repository/CustomJpaRepositoryTest.java
@@ -11,6 +11,7 @@ import java.sql.SQLException;
 import jdbc.JdbcTemplate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import persistence.entity.EntityManager;
 import persistence.entity.EntityManagerImpl;
@@ -60,6 +61,7 @@ class CustomJpaRepositoryTest {
         server.stop();
     }
 
+    @DisplayName("save 후 나오는 person 은 기존 객체와 같은 값을 갖는다.")
     @Test
     void test_insert() {
         Person person = new Person("tongnamuu", 12, "tongnamuu@naver.com");
@@ -71,6 +73,7 @@ class CustomJpaRepositoryTest {
         );
     }
 
+    @DisplayName("update 후에는 update 된 값이 조회된다.")
     @Test
     void test_update() {
         Person person = new Person("tongnamuu", 12, "tongnamuu@naver.com");

--- a/src/test/java/repository/CustomJpaRepositoryTest.java
+++ b/src/test/java/repository/CustomJpaRepositoryTest.java
@@ -1,7 +1,89 @@
 package repository;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static persistence.TestUtils.createDataDefinitionLanguageAssembler;
+import static persistence.TestUtils.createDataManipulationLanguageAssembler;
+
+import database.DatabaseServer;
+import database.H2;
+import java.sql.SQLException;
+import jdbc.JdbcTemplate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import persistence.entity.EntityManager;
+import persistence.entity.EntityManagerImpl;
+import persistence.entity.Person;
+import persistence.entity.loader.EntityLoader;
+import persistence.entity.persister.EntityPersister;
+import persistence.sql.ddl.assembler.DataDefinitionLanguageAssembler;
+import persistence.sql.dml.assembler.DataManipulationLanguageAssembler;
+import persistence.sql.usecase.CreateSnapShotObject;
+import persistence.sql.usecase.GetFieldFromClassUseCase;
+import persistence.sql.usecase.GetFieldValueUseCase;
+import persistence.sql.usecase.GetIdDatabaseFieldUseCase;
+import persistence.sql.usecase.SetFieldValueUseCase;
 
 class CustomJpaRepositoryTest {
-    
+    private final DataManipulationLanguageAssembler dataManipulationLanguageAssembler = createDataManipulationLanguageAssembler();
+    private final DataDefinitionLanguageAssembler dataDefinitionLanguageAssembler = createDataDefinitionLanguageAssembler();
+    private DatabaseServer server;
+    private JdbcTemplate jdbcTemplate;
+    private EntityPersister entityPersister;
+    private EntityLoader entityLoader;
+    private EntityManager entityManager;
+
+    private CustomJpaRepository<Person, Long> customJpaRepository;
+
+    @BeforeEach
+    void setup() throws SQLException {
+        server = new H2();
+        server.start();
+        jdbcTemplate = new JdbcTemplate(server.getConnection());
+        entityPersister = new EntityPersister(dataManipulationLanguageAssembler, jdbcTemplate);
+        entityLoader = new EntityLoader(new GetFieldFromClassUseCase(), new SetFieldValueUseCase(), jdbcTemplate, dataManipulationLanguageAssembler);
+        entityManager = new EntityManagerImpl(entityLoader,
+            entityPersister,
+            new GetIdDatabaseFieldUseCase(new GetFieldFromClassUseCase()),
+            new GetFieldValueUseCase(),
+            new SetFieldValueUseCase(),
+            new CreateSnapShotObject(new GetFieldFromClassUseCase(), new GetFieldValueUseCase(), new SetFieldValueUseCase())
+        );
+        jdbcTemplate.execute(dataDefinitionLanguageAssembler.assembleCreateTableQuery(Person.class));
+        customJpaRepository = new CustomJpaRepository<>(entityManager);
+    }
+
+    @AfterEach
+    void tearDown() {
+        jdbcTemplate.execute(dataDefinitionLanguageAssembler.assembleDropTableQuery(Person.class));
+        server.stop();
+    }
+
+    @Test
+    void test_insert() {
+        Person person = new Person("tongnamuu", 12, "tongnamuu@naver.com");
+        Person person1 = customJpaRepository.save(person);
+        assertAll(
+            () -> assertThat(person1.getName()).isEqualTo("tongnamuu"),
+            () -> assertThat(person1.getAge()).isEqualTo(12),
+            () -> assertThat(person1.getEmail()).isEqualTo("tongnamuu@naver.com")
+        );
+    }
+
+    @Test
+    void test_update() {
+        Person person = new Person("tongnamuu", 12, "tongnamuu@naver.com");
+        customJpaRepository.save(person);
+        person.updateEmail("hello@gmail.com");
+        Person person1 = customJpaRepository.save(person);
+        entityManager.clear();
+        Person findPerson = entityManager.find(person1.getClass(), person1.getId());
+
+        assertAll(
+            () -> assertThat(findPerson.getName()).isEqualTo("tongnamuu"),
+            () -> assertThat(findPerson.getAge()).isEqualTo(12),
+            () -> assertThat(findPerson.getEmail()).isEqualTo("hello@gmail.com")
+        );
+    }
 }

--- a/src/test/java/repository/CustomJpaRepositoryTest.java
+++ b/src/test/java/repository/CustomJpaRepositoryTest.java
@@ -1,0 +1,7 @@
+package repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CustomJpaRepositoryTest {
+    
+}


### PR DESCRIPTION
안녕하세요 성주님 3단계 pr올립니다.
id가 없으면 insert
있으면 디비 조회 후 있으면 update, 없으면 insert 하게 만들었습니다.

update 도 원본값과 다른 경우에 일어나도록 했습니다.


아래는 이전 코멘트관련입니다.


> `특정 클래스의 id가 있을 경우 List 로 나오는 경우가 있나요?`

id가 유니크함을 어디선가 보장해줘야 한다고 생각했습니다. 하지만 완전한 외부의존성인 디비의 primary key 혹은 unique 설정에만 의존하는 것은 적절하지 않은듯하여 코드단에서 한 번 체크하도록 구현했습니다.

> `usecase` 관련 네이밍은 여러 자료에서 참고를 했습니다.

https://github.com/mattia-battiston/clean-architecture-example/blob/master/application/core/src/main/java/com/clean/example/core/usecase/broadbandaccessdevice/getdetails/GetBroadbandAccessDeviceDetailsUseCase.java 
여기서는 usecase 를 붙이기도 하고혹은 verbal class 를 사용하기도 하는 것 같습니다. 
https://medium.com/@wladislavk/noun-classes-and-verb-classes-b39eebb5c942#:~:text=Verb%2D-,classes,-An%20object%20of
usecase diagram 이 애초에 동사로 작성되고 그걸 그대로 구현해서 서비스 클래스 하나 당 메소드가 1개인 형태로 유지하게 됩니다. 
여기서는 인터페이스로 빼지는 않았는데
첫 번째 장점은 실무에서는 Functional Interface 형태로 만들수 있게 되고,  mock/stub 대신 fake 객체를 만드는게 람다형태로 표현가능해져서 꽤나 유용하다고 생각합니다. 
또 완전히 재사용가능한 형태로 메소드가 존재하게 되는 장점이 있습니다. 하나의 클래스에 여러 메서드를 뒀을 때, Transactional 이 붙지 않은 퍼블릭 메서드가 Transactional 이 붙은 메서드를 호출했을 때 Transaction이 동작하지 않는데, 이렇게 해두면 트랜잭션이 항상 동작하게 되는 장점이 있는 것 같습니다.

