### PR TITLE
[Step2 - 엔터티 초기화 (EntityLoader)] 김현태 미션 제출합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,13 @@
 
 ## 요구사항 2 - EntityManager의 책임 줄여주기
 - [x] EntityManager의 persist, remove 책임 EntityPersister로 이동
+
+# 2단계 - 엔터티 초기화
+
+## 요구사항 1 - RowMapper 리팩터링
+- [x] EntityLoader를 통해 조회할 수 있다.
+- [x] RowMapperFactory를 이용해 RowMapper를 만들 수 있다.
+
+## 요구사항 2 - EntityManager의 책임 줄여주기
+- [ ] find 책임을 EntityLoader로 이동
+

--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@
 - [x] RowMapperFactory를 이용해 RowMapper를 만들 수 있다.
 
 ## 요구사항 2 - EntityManager의 책임 줄여주기
-- [ ] find 책임을 EntityLoader로 이동
+- [x] find 책임을 EntityLoader로 이동
 

--- a/src/main/java/persistence/entity/EntityLoader.java
+++ b/src/main/java/persistence/entity/EntityLoader.java
@@ -1,0 +1,6 @@
+package persistence.entity;
+
+public interface EntityLoader {
+
+    <T> T find(Class<T> clazz, Object Id);
+}

--- a/src/main/java/persistence/entity/MyEntityLoader.java
+++ b/src/main/java/persistence/entity/MyEntityLoader.java
@@ -1,0 +1,23 @@
+package persistence.entity;
+
+import jdbc.JdbcTemplate;
+import jdbc.RowMapper;
+import persistence.sql.dml.SelectQueryBuilder;
+
+public class MyEntityLoader implements EntityLoader {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final SelectQueryBuilder selectQueryBuilder;
+
+    public MyEntityLoader(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.selectQueryBuilder = SelectQueryBuilder.getInstance();
+    }
+
+    @Override
+    public <T> T find(Class<T> clazz, Object Id) {
+        String query = selectQueryBuilder.build(clazz, Id);
+        RowMapper<T> rowMapper = RowMapperFactory.create(clazz);
+        return jdbcTemplate.queryForObject(query, rowMapper);
+    }
+}

--- a/src/main/java/persistence/entity/MyEntityManager.java
+++ b/src/main/java/persistence/entity/MyEntityManager.java
@@ -6,7 +6,7 @@ import persistence.sql.dml.SelectQueryBuilder;
 public class MyEntityManager implements EntityManager {
 
     private final JdbcTemplate jdbcTemplate;
-    private final MyEntityPersister entityPersister;
+    private final EntityPersister entityPersister;
 
     public MyEntityManager(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;

--- a/src/main/java/persistence/entity/MyEntityManager.java
+++ b/src/main/java/persistence/entity/MyEntityManager.java
@@ -16,7 +16,7 @@ public class MyEntityManager implements EntityManager {
     //TODO entityLoader 생성 후 jdbcTemplate 제거 및 해당 메서드 책임 이전
     @Override
     public <T> T find(Class<T> clazz, Long Id) {
-        SelectQueryBuilder selectQueryBuilder = new SelectQueryBuilder();
+        SelectQueryBuilder selectQueryBuilder = SelectQueryBuilder.getInstance();
         String query = selectQueryBuilder.build(clazz, Id);
         return jdbcTemplate.queryForObject(query, RowMapperFactory.create(clazz));
     }

--- a/src/main/java/persistence/entity/MyEntityManager.java
+++ b/src/main/java/persistence/entity/MyEntityManager.java
@@ -1,24 +1,20 @@
 package persistence.entity;
 
 import jdbc.JdbcTemplate;
-import persistence.sql.dml.SelectQueryBuilder;
 
 public class MyEntityManager implements EntityManager {
 
-    private final JdbcTemplate jdbcTemplate;
     private final EntityPersister entityPersister;
+    private final EntityLoader entityLoader;
 
     public MyEntityManager(JdbcTemplate jdbcTemplate) {
-        this.jdbcTemplate = jdbcTemplate;
         this.entityPersister = new MyEntityPersister(jdbcTemplate);
+        this.entityLoader = new MyEntityLoader(jdbcTemplate);
     }
 
-    //TODO entityLoader 생성 후 jdbcTemplate 제거 및 해당 메서드 책임 이전
     @Override
     public <T> T find(Class<T> clazz, Long Id) {
-        SelectQueryBuilder selectQueryBuilder = SelectQueryBuilder.getInstance();
-        String query = selectQueryBuilder.build(clazz, Id);
-        return jdbcTemplate.queryForObject(query, RowMapperFactory.create(clazz));
+        return entityLoader.find(clazz, Id);
     }
 
     @Override

--- a/src/main/java/persistence/entity/MyEntityPersister.java
+++ b/src/main/java/persistence/entity/MyEntityPersister.java
@@ -8,25 +8,28 @@ import persistence.sql.dml.UpdateQueryBuilder;
 public class MyEntityPersister implements EntityPersister {
 
     private final JdbcTemplate jdbcTemplate;
+    private final InsertQueryBuilder insertQueryBuilder;
+    private final UpdateQueryBuilder updateQueryBuilder;
+    private final DeleteQueryBuilder deleteQueryBuilder;
 
     public MyEntityPersister(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
+        this.insertQueryBuilder = InsertQueryBuilder.getInstance();
+        this.updateQueryBuilder = UpdateQueryBuilder.getInstance();
+        this.deleteQueryBuilder = DeleteQueryBuilder.getInstance();
     }
 
     public boolean update(Object entity) {
-        UpdateQueryBuilder updateQueryBuilder = new UpdateQueryBuilder();
         String query = updateQueryBuilder.build(entity);
         return jdbcTemplate.executeForUpdate(query);
     }
 
     public void insert(Object entity) {
-        InsertQueryBuilder insertQueryBuilder = new InsertQueryBuilder();
         String query = insertQueryBuilder.build(entity);
         jdbcTemplate.execute(query);
     }
 
     public void delete(Object entity) {
-        DeleteQueryBuilder deleteQueryBuilder = new DeleteQueryBuilder();
         String query = deleteQueryBuilder.build(entity);
         jdbcTemplate.execute(query);
     }

--- a/src/main/java/persistence/sql/dml/DeleteQueryBuilder.java
+++ b/src/main/java/persistence/sql/dml/DeleteQueryBuilder.java
@@ -7,9 +7,16 @@ import persistence.sql.domain.Table;
 import java.lang.reflect.Field;
 
 public class DeleteQueryBuilder {
-
     private static final String DELETE_QUERY_TEMPLATE = "DELETE FROM %s";
     private static final String WHERE_CLAUSE_TEMPLATE = " WHERE %s = %s";
+
+    private static class InstanceHolder {
+        private static final DeleteQueryBuilder INSTANCE = new DeleteQueryBuilder();
+    }
+
+    public static DeleteQueryBuilder getInstance() {
+        return InstanceHolder.INSTANCE;
+    }
 
     public String build(Object object) {
         Table table = Table.from(object.getClass());

--- a/src/main/java/persistence/sql/dml/InsertQueryBuilder.java
+++ b/src/main/java/persistence/sql/dml/InsertQueryBuilder.java
@@ -36,7 +36,7 @@ public class InsertQueryBuilder {
         return columns.stream()
                 .filter(column -> !column.isAutoIncrementId())
                 .peek(column -> checkNullableValue(object, column))
-                .collect(Collectors.toMap(Column::getName, column -> getDmlName(object, column),
+                .collect(Collectors.toMap(Column::getName, column -> getDmlValue(object, column),
                         (existingValue, newValue) -> existingValue, LinkedHashMap::new));
     }
 
@@ -56,7 +56,7 @@ public class InsertQueryBuilder {
         }
     }
 
-    private String getDmlName(Object object, Column column) {
+    private String getDmlValue(Object object, Column column) {
         Object value = getObject(object, column);
         DataType columnType = column.getType();
         if (columnType.isVarchar()) {

--- a/src/main/java/persistence/sql/dml/InsertQueryBuilder.java
+++ b/src/main/java/persistence/sql/dml/InsertQueryBuilder.java
@@ -14,6 +14,15 @@ public class InsertQueryBuilder {
     private static final String INSERT_QUERY_TEMPLATE = "INSERT INTO %s (%s) VALUES (%s)";
     private static final String CLAUSE_DELIMITER = ", ";
 
+    private static class InstanceHolder {
+        private static final InsertQueryBuilder INSTANCE = new InsertQueryBuilder();
+    }
+
+    public static InsertQueryBuilder getInstance() {
+        return InstanceHolder.INSTANCE;
+    }
+
+
     public String build(Object object) {
         Table table = Table.from(object.getClass());
         List<Column> columns = table.getColumns();

--- a/src/main/java/persistence/sql/dml/SelectAllQueryBuilder.java
+++ b/src/main/java/persistence/sql/dml/SelectAllQueryBuilder.java
@@ -10,6 +10,15 @@ public class SelectAllQueryBuilder {
     private static final String FIND_ALL_QUERY_TEMPLATE = "SELECT %s FROM %s";
     private static final String COLUMN_DELIMITER = ", ";
 
+    private static class InstanceHolder {
+        private static final SelectAllQueryBuilder INSTANCE = new SelectAllQueryBuilder();
+    }
+
+    public static SelectAllQueryBuilder getInstance() {
+        return InstanceHolder.INSTANCE;
+    }
+
+
     public String build(Class<?> target) {
         Table table = Table.from(target);
         String columnNames = getColumnsNames(table.getColumns());

--- a/src/main/java/persistence/sql/dml/SelectQueryBuilder.java
+++ b/src/main/java/persistence/sql/dml/SelectQueryBuilder.java
@@ -1,6 +1,8 @@
 package persistence.sql.dml;
 
 import persistence.sql.domain.Column;
+import persistence.sql.domain.DataType;
+import persistence.sql.domain.IdColumn;
 import persistence.sql.domain.Table;
 
 import java.util.List;
@@ -8,7 +10,7 @@ import java.util.stream.Collectors;
 
 public class SelectQueryBuilder {
     private static final String SELECT_QUERY_TEMPLATE = "SELECT %s FROM %s";
-    private static final String WHERE_CLAUSE_TEMPLATE = " WHERE %s = %d";
+    private static final String WHERE_CLAUSE_TEMPLATE = " WHERE %s = %s";
     private static final String COLUMN_DELIMITER = ", ";
 
     private static class InstanceHolder {
@@ -35,7 +37,16 @@ public class SelectQueryBuilder {
     }
 
     private String whereClause(Table table, Object id) {
-        String name = table.getIdColumn().getName();
-        return String.format(WHERE_CLAUSE_TEMPLATE, name, id);
+        IdColumn idColumn = table.getIdColumn();
+        String value = getDmlValue(id, idColumn);
+        return String.format(WHERE_CLAUSE_TEMPLATE, idColumn.getName(), value);
+    }
+
+    private String getDmlValue(Object id, Column column) {
+        DataType columnType = column.getType();
+        if (columnType.isVarchar()) {
+            return String.format("'%s'", id);
+        }
+        return id.toString();
     }
 }

--- a/src/main/java/persistence/sql/dml/SelectQueryBuilder.java
+++ b/src/main/java/persistence/sql/dml/SelectQueryBuilder.java
@@ -11,6 +11,15 @@ public class SelectQueryBuilder {
     private static final String WHERE_CLAUSE_TEMPLATE = " WHERE %s = %d";
     private static final String COLUMN_DELIMITER = ", ";
 
+    private static class InstanceHolder {
+        private static final SelectQueryBuilder INSTANCE = new SelectQueryBuilder();
+    }
+
+    public static SelectQueryBuilder getInstance() {
+        return InstanceHolder.INSTANCE;
+    }
+
+
     public String build(Class<?> target, Object id) {
         Table table = Table.from(target);
         String columnsNames = getColumnsNames(table.getColumns());

--- a/src/main/java/persistence/sql/dml/UpdateQueryBuilder.java
+++ b/src/main/java/persistence/sql/dml/UpdateQueryBuilder.java
@@ -14,6 +14,15 @@ import java.util.stream.Collectors;
 public class UpdateQueryBuilder {
     private static final String UPDATE_QUERY_TEMPLATE = "UPDATE %s SET %s WHERE %s = %s";
 
+    private static class InstanceHolder {
+        private static final UpdateQueryBuilder INSTANCE = new UpdateQueryBuilder();
+    }
+
+    public static UpdateQueryBuilder getInstance() {
+        return InstanceHolder.INSTANCE;
+    }
+
+
     public String build(Object object) {
         Table table = Table.from(object.getClass());
         IdColumn idColumn = table.getIdColumn();

--- a/src/main/java/persistence/sql/dml/UpdateQueryBuilder.java
+++ b/src/main/java/persistence/sql/dml/UpdateQueryBuilder.java
@@ -41,11 +41,11 @@ public class UpdateQueryBuilder {
     private LinkedHashMap<String, String> getColumnClause(Object object, List<Column> columns) {
         return columns.stream()
                 .filter(column -> !column.isId())
-                .collect(Collectors.toMap(Column::getName, column -> getDmlName(object, column),
+                .collect(Collectors.toMap(Column::getName, column -> getDmlValue(object, column),
                         (existingValue, newValue) -> existingValue, LinkedHashMap::new));
     }
 
-    private String getDmlName(Object object, Column column) {
+    private String getDmlValue(Object object, Column column) {
         Object value = getValue(object, column);
         DataType columnType = column.getType();
         if (columnType.isVarchar()) {

--- a/src/test/java/persistence/entity/MyEntityLoaderTest.java
+++ b/src/test/java/persistence/entity/MyEntityLoaderTest.java
@@ -1,0 +1,50 @@
+package persistence.entity;
+
+import jdbc.JdbcTemplate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import persistence.sql.Person;
+import persistence.sql.ddl.CreateQueryBuilder;
+import persistence.sql.ddl.DropQueryBuilder;
+import persistence.sql.domain.dialect.H2Dialect;
+import persistence.support.DatabaseSetup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DatabaseSetup
+class MyEntityLoaderTest {
+
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+        CreateQueryBuilder createQueryBuilder = new CreateQueryBuilder(new H2Dialect());
+        String createQuery = createQueryBuilder.build(Person.class);
+        jdbcTemplate.execute(createQuery);
+    }
+
+    @AfterEach
+    void tearDown(JdbcTemplate jdbcTemplate) {
+        DropQueryBuilder dropQueryBuilder = new DropQueryBuilder(new H2Dialect());
+        String dropQuery = dropQueryBuilder.build(Person.class);
+        jdbcTemplate.execute(dropQuery);
+    }
+
+    @Test
+    void find() {
+        //given
+        MyEntityManager entityManager = new MyEntityManager(jdbcTemplate);
+        EntityLoader entityLoader = new MyEntityLoader(jdbcTemplate);
+        String expectName = "ABC";
+        entityManager.persist(new Person(1L, expectName, 10, "ABC@email.com", 10));
+
+        //when
+        Person actual = entityLoader.find(Person.class, 1L);
+
+        //then
+        assertThat(actual).extracting("name")
+                .isEqualTo(expectName);
+    }
+}

--- a/src/test/java/persistence/entity/MyEntityManagerTest.java
+++ b/src/test/java/persistence/entity/MyEntityManagerTest.java
@@ -1,7 +1,5 @@
 package persistence.entity;
 
-import database.DatabaseServer;
-import database.H2;
 import jdbc.JdbcTemplate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,28 +10,26 @@ import persistence.sql.ddl.CreateQueryBuilder;
 import persistence.sql.ddl.DropQueryBuilder;
 import persistence.sql.dml.InsertQueryBuilder;
 import persistence.sql.domain.dialect.H2Dialect;
-
-import java.sql.SQLException;
+import persistence.support.DatabaseSetup;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@DatabaseSetup
 class MyEntityManagerTest {
 
     private JdbcTemplate jdbcTemplate;
 
     @BeforeEach
-    void setUp() throws SQLException {
-        DatabaseServer server = new H2();
-        server.start();
-        jdbcTemplate = new JdbcTemplate(server.getConnection());
+    void setUp(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
         CreateQueryBuilder createQueryBuilder = new CreateQueryBuilder(new H2Dialect());
         String createQuery = createQueryBuilder.build(Person.class);
         jdbcTemplate.execute(createQuery);
     }
 
     @AfterEach
-    void tearDown() {
+    void tearDown(JdbcTemplate jdbcTemplate) {
         DropQueryBuilder dropQueryBuilder = new DropQueryBuilder(new H2Dialect());
         String dropQuery = dropQueryBuilder.build(Person.class);
         jdbcTemplate.execute(dropQuery);

--- a/src/test/java/persistence/entity/MyEntityPersisterTest.java
+++ b/src/test/java/persistence/entity/MyEntityPersisterTest.java
@@ -1,7 +1,5 @@
 package persistence.entity;
 
-import database.DatabaseServer;
-import database.H2;
 import jdbc.JdbcTemplate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,28 +9,27 @@ import persistence.sql.ddl.CreateQueryBuilder;
 import persistence.sql.ddl.DropQueryBuilder;
 import persistence.sql.dml.SelectAllQueryBuilder;
 import persistence.sql.domain.dialect.H2Dialect;
+import persistence.support.DatabaseSetup;
 
-import java.sql.SQLException;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+@DatabaseSetup
 class MyEntityPersisterTest {
     private JdbcTemplate jdbcTemplate;
 
     @BeforeEach
-    void setUp() throws SQLException {
-        DatabaseServer server = new H2();
-        server.start();
-        jdbcTemplate = new JdbcTemplate(server.getConnection());
+    void setUp(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
         CreateQueryBuilder createQueryBuilder = new CreateQueryBuilder(new H2Dialect());
         String createQuery = createQueryBuilder.build(Person.class);
         jdbcTemplate.execute(createQuery);
     }
 
     @AfterEach
-    void tearDown() {
+    void tearDown(JdbcTemplate jdbcTemplate) {
         DropQueryBuilder dropQueryBuilder = new DropQueryBuilder(new H2Dialect());
         String dropQuery = dropQueryBuilder.build(Person.class);
         jdbcTemplate.execute(dropQuery);

--- a/src/test/java/persistence/sql/dml/DeleteQueryBuilderTest.java
+++ b/src/test/java/persistence/sql/dml/DeleteQueryBuilderTest.java
@@ -13,7 +13,7 @@ class DeleteQueryBuilderTest {
     void buildDeleteQuery() {
         //given
         Person person = new Person(1L, "name", 1, "email", 1);
-        DeleteQueryBuilder deleteQueryBuilder = new DeleteQueryBuilder();
+        DeleteQueryBuilder deleteQueryBuilder = DeleteQueryBuilder.getInstance();
 
         //when
         String query = deleteQueryBuilder.build(person);

--- a/src/test/java/persistence/sql/dml/InsertQueryBuilderTest.java
+++ b/src/test/java/persistence/sql/dml/InsertQueryBuilderTest.java
@@ -13,7 +13,7 @@ class InsertQueryBuilderTest {
     void buildInsertQuery() {
         //given
         Person person = new Person(1L, "name", 1, "email", 1);
-        InsertQueryBuilder insertQueryBuilder = new InsertQueryBuilder();
+        InsertQueryBuilder insertQueryBuilder = InsertQueryBuilder.getInstance();
 
         //when
         String query = insertQueryBuilder.build(person);

--- a/src/test/java/persistence/sql/dml/SelectAllQueryBuilderTest.java
+++ b/src/test/java/persistence/sql/dml/SelectAllQueryBuilderTest.java
@@ -12,7 +12,7 @@ class SelectAllQueryBuilderTest {
     @DisplayName("findAll 쿼리를 만들 수 있다.")
     void buildFindAllQuery() {
         //given
-        SelectAllQueryBuilder selectAllQueryBuilder = new SelectAllQueryBuilder();
+        SelectAllQueryBuilder selectAllQueryBuilder = SelectAllQueryBuilder.getInstance();
 
         //when
         String query = selectAllQueryBuilder.build(Person.class);

--- a/src/test/java/persistence/sql/dml/SelectQueryBuilderTest.java
+++ b/src/test/java/persistence/sql/dml/SelectQueryBuilderTest.java
@@ -12,7 +12,7 @@ class SelectQueryBuilderTest {
     @DisplayName("select 쿼리를 만들 수 있다.")
     void buildFindQuery() {
         //given
-        SelectQueryBuilder selectQueryBuilder = new SelectQueryBuilder();
+        SelectQueryBuilder selectQueryBuilder = SelectQueryBuilder.getInstance();
 
         //when
         String query = selectQueryBuilder.build(Person.class, 1L);

--- a/src/test/java/persistence/sql/dml/UpdateQueryBuilderTest.java
+++ b/src/test/java/persistence/sql/dml/UpdateQueryBuilderTest.java
@@ -12,7 +12,7 @@ class UpdateQueryBuilderTest {
     @Test
     @DisplayName("update 쿼리를 만들 수 있다.")
     void buildUpdateQuery() {
-        UpdateQueryBuilder updateQueryBuilder = new UpdateQueryBuilder();
+        UpdateQueryBuilder updateQueryBuilder = UpdateQueryBuilder.getInstance();
         Person name = new Person(1L, "name", 10, "email.com", 1);
         String query = updateQueryBuilder.build(name);
         assertThat(query).isEqualTo("UPDATE users SET nick_name = 'name', old = 10, email = 'email.com' WHERE id = 1");

--- a/src/test/java/persistence/support/DatabaseSetup.java
+++ b/src/test/java/persistence/support/DatabaseSetup.java
@@ -1,0 +1,14 @@
+package persistence.support;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@ExtendWith(DatabaseSetupExtension.class)
+public @interface DatabaseSetup {
+}

--- a/src/test/java/persistence/support/DatabaseSetupExtension.java
+++ b/src/test/java/persistence/support/DatabaseSetupExtension.java
@@ -1,0 +1,39 @@
+package persistence.support;
+
+import database.DatabaseServer;
+import database.H2;
+import jdbc.JdbcTemplate;
+import org.junit.jupiter.api.extension.*;
+
+public class DatabaseSetupExtension implements BeforeAllCallback, AfterAllCallback, ParameterResolver {
+
+    private DatabaseServer server;
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        server = new H2();
+        server.start();
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(server.getConnection());
+
+        getStore(context).put("jdbcTemplate", jdbcTemplate);
+    }
+
+    private ExtensionContext.Store getStore(ExtensionContext context) {
+        return context.getStore(ExtensionContext.Namespace.create(DatabaseSetupExtension.class, context.getRequiredTestClass()));
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) {
+        server.stop();
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return parameterContext.getParameter().getType() == JdbcTemplate.class;
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return getStore(extensionContext).get("jdbcTemplate");
+    }
+}


### PR DESCRIPTION
안녕하세요 정원님,
이전 [PR](https://github.com/next-step/jpa-entity-manager/pull/98)에서 요청해주신 피드백은 저도 정원님 의견에 동의하여 모두 반영하였습니다.

```
<반영 내용>
1. Test 시 DB 서버를 한번만 실행시키도록 구현
2. QueryBuilder를 싱글톤으로 관리하고, EntityPersister 에서 재사용할 수 있도록 구현
```
바쁘신 와중에 꼼곰히 읽어주셔서 감사합니다.
기존에 만들어둔 `RowMapperFactory`와 `SelectQueryBuilder`를 사용하니 수정사항이 많지는 않더라구요.
이번 단계도 잘 부탁드립니다.🙇🏻‍♂️