### PR TITLE
🚀 2단계 - 엔터티 초기화 (EntityLoader)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@
 
 ## Step2 요구사항
 - [ ] RowMapper
-- [ ] EntityLoader
+- [x] EntityLoader
 - [ ] PK 관련 리팩토링

--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@
   - [x] delete
 
 ## Step2 요구사항
-- [ ] RowMapper
+- [x] RowMapper
 - [x] EntityLoader
 - [ ] PK 관련 리팩토링

--- a/README.md
+++ b/README.md
@@ -9,3 +9,8 @@
   - [x] insert
   - [x] update
   - [x] delete
+
+## Step2 요구사항
+- [ ] RowMapper
+- [ ] EntityLoader
+- [ ] PK 관련 리팩토링

--- a/src/main/java/jdbc/RowMapperImpl.java
+++ b/src/main/java/jdbc/RowMapperImpl.java
@@ -39,15 +39,7 @@ public class RowMapperImpl<T> implements RowMapper<T> {
     private void setValue(T object, Field field, ResultSet resultSet) throws SQLException {
         try {
             String columnName = new ColumnName(field).getName();
-            if (field.getType().equals(Long.class)) {
-                field.set(object, resultSet.getLong(columnName));
-            }
-            if (field.getType().equals(Integer.class)) {
-                field.set(object, resultSet.getInt(columnName));
-            }
-            if (field.getType().equals(String.class)) {
-                field.set(object, resultSet.getString(columnName));
-            }
+            field.set(object, resultSet.getObject(columnName));
         } catch (IllegalAccessException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/persistence/entity/EntityLoader.java
+++ b/src/main/java/persistence/entity/EntityLoader.java
@@ -5,6 +5,7 @@ import jdbc.RowMapperImpl;
 import persistence.sql.dml.builder.SelectQueryBuilder;
 
 import java.util.List;
+import java.util.Optional;
 
 public class EntityLoader {
 
@@ -16,19 +17,24 @@ public class EntityLoader {
         this.selectQueryBuilder = new SelectQueryBuilder();
     }
 
-    public <T> T findOne(T entity, Long id) {
-        List<T> entities = (List<T>) jdbcTemplate.query(
-                selectQueryBuilder.findById(entity.getClass(), id),
-                new RowMapperImpl<>(entity.getClass())
+    public <T> Optional<T> findOne(Class<T> clazz, Long id) {
+        List<T> entities = jdbcTemplate.query(
+                selectQueryBuilder.findById(clazz, id),
+                new RowMapperImpl<>(clazz)
         );
         if (entities.isEmpty()) {
-            return null;
+            return Optional.empty();
         }
-        return entities.get(0);
+        return Optional.ofNullable(entities.get(0));
     }
 
-    public <T> T findOneOrFail(Class<T> clazz, Long id) {
-        return jdbcTemplate.queryForObject(selectQueryBuilder.findById(clazz, id), new RowMapperImpl<>(clazz));
+    public <T> Optional<T> findOne(T entity, Long id) {
+        List<?> entities = jdbcTemplate.query(
+                selectQueryBuilder.findById(entity.getClass(), id),
+                new RowMapperImpl<>(entity.getClass()));
+        if (entities.isEmpty()) {
+            return Optional.empty();
+        }
+        return (Optional<T>) Optional.ofNullable(entities.get(0));
     }
-
 }

--- a/src/main/java/persistence/entity/EntityLoader.java
+++ b/src/main/java/persistence/entity/EntityLoader.java
@@ -29,12 +29,7 @@ public class EntityLoader {
     }
 
     public <T> Optional<T> findOne(T entity, Long id) {
-        List<?> entities = jdbcTemplate.query(
-                selectQueryBuilder.findById(entity.getClass(), id),
-                new RowMapperImpl<>(entity.getClass()));
-        if (entities.isEmpty()) {
-            return Optional.empty();
-        }
-        return (Optional<T>) Optional.ofNullable(entities.get(0));
+        Class<T> clazz = (Class<T>) entity.getClass();
+        return findOne(clazz, id);
     }
 }

--- a/src/main/java/persistence/entity/EntityLoader.java
+++ b/src/main/java/persistence/entity/EntityLoader.java
@@ -1,0 +1,34 @@
+package persistence.entity;
+
+import jdbc.JdbcTemplate;
+import jdbc.RowMapperImpl;
+import persistence.sql.dml.builder.SelectQueryBuilder;
+
+import java.util.List;
+
+public class EntityLoader {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final SelectQueryBuilder selectQueryBuilder;
+
+    public EntityLoader(final JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.selectQueryBuilder = new SelectQueryBuilder();
+    }
+
+    public <T> T findOne(T entity, Long id) {
+        List<T> entities = (List<T>) jdbcTemplate.query(
+                selectQueryBuilder.findById(entity.getClass(), id),
+                new RowMapperImpl<>(entity.getClass())
+        );
+        if (entities.isEmpty()) {
+            return null;
+        }
+        return entities.get(0);
+    }
+
+    public <T> T findOneOrFail(Class<T> clazz, Long id) {
+        return jdbcTemplate.queryForObject(selectQueryBuilder.findById(clazz, id), new RowMapperImpl<>(clazz));
+    }
+
+}

--- a/src/main/java/persistence/entity/EntityManagerImpl.java
+++ b/src/main/java/persistence/entity/EntityManagerImpl.java
@@ -2,6 +2,8 @@ package persistence.entity;
 
 import jdbc.JdbcTemplate;
 
+import java.util.Optional;
+
 public class EntityManagerImpl<T> implements EntityManager<T> {
     private final EntityLoader entityLoader;
     private final EntityPersist entityPersist;
@@ -13,7 +15,8 @@ public class EntityManagerImpl<T> implements EntityManager<T> {
 
     @Override
     public T find(Class<T> clazz, Long id) {
-        return entityLoader.findOneOrFail(clazz, id);
+        return entityLoader.findOne(clazz, id)
+                .orElseThrow(() -> new IllegalArgumentException(String.format("entity id: %s not found", id)));
     }
 
     @Override
@@ -23,8 +26,8 @@ public class EntityManagerImpl<T> implements EntityManager<T> {
             entityPersist.insert(entity);
             return;
         }
-        T findEntity = entityLoader.findOne(entity, pkValue);
-        if (findEntity == null) {
+        Optional<T> findEntity = entityLoader.findOne(entity, pkValue);
+        if (findEntity.isEmpty()) {
             entityPersist.insert(entity);
             return;
         }

--- a/src/main/java/persistence/entity/EntityManagerImpl.java
+++ b/src/main/java/persistence/entity/EntityManagerImpl.java
@@ -1,7 +1,9 @@
 package persistence.entity;
 
 import jdbc.JdbcTemplate;
+import persistence.sql.meta.pk.PKField;
 
+import java.lang.reflect.Field;
 import java.util.Optional;
 
 public class EntityManagerImpl<T> implements EntityManager<T> {
@@ -21,7 +23,7 @@ public class EntityManagerImpl<T> implements EntityManager<T> {
 
     @Override
     public void persist(T entity) {
-        Long pkValue = entityPersist.getPKValue(entity);
+        Long pkValue = getPKValue(entity);
         if (pkValue == null) {
             entityPersist.insert(entity);
             return;
@@ -37,5 +39,17 @@ public class EntityManagerImpl<T> implements EntityManager<T> {
     @Override
     public void remove(T entity) {
         entityPersist.delete(entity);
+    }
+
+    private Long getPKValue(T entity) {
+        Field pkField = new PKField(entity.getClass()).getField();
+        pkField.setAccessible(true);
+        Long value;
+        try {
+            value = (Long) pkField.get(entity);
+        } catch (IllegalAccessException e) {
+            throw new IllegalArgumentException(e);
+        }
+        return value;
     }
 }

--- a/src/main/java/persistence/entity/EntityManagerImpl.java
+++ b/src/main/java/persistence/entity/EntityManagerImpl.java
@@ -3,15 +3,17 @@ package persistence.entity;
 import jdbc.JdbcTemplate;
 
 public class EntityManagerImpl<T> implements EntityManager<T> {
+    private final EntityLoader entityLoader;
     private final EntityPersist entityPersist;
 
     public EntityManagerImpl(JdbcTemplate jdbcTemplate) {
+        this.entityLoader = new EntityLoader(jdbcTemplate);
         this.entityPersist = new EntityPersist(jdbcTemplate);
     }
 
     @Override
     public T find(Class<T> clazz, Long id) {
-        return entityPersist.findOneOrFail(clazz, id);
+        return entityLoader.findOneOrFail(clazz, id);
     }
 
     @Override
@@ -21,7 +23,7 @@ public class EntityManagerImpl<T> implements EntityManager<T> {
             entityPersist.insert(entity);
             return;
         }
-        T findEntity = entityPersist.findOne(entity, pkValue);
+        T findEntity = entityLoader.findOne(entity, pkValue);
         if (findEntity == null) {
             entityPersist.insert(entity);
             return;

--- a/src/main/java/persistence/entity/EntityPersist.java
+++ b/src/main/java/persistence/entity/EntityPersist.java
@@ -1,33 +1,24 @@
 package persistence.entity;
 
 import jdbc.JdbcTemplate;
-import jdbc.RowMapperImpl;
 import persistence.sql.dml.builder.DeleteQueryBuilder;
 import persistence.sql.dml.builder.InsertQueryBuilder;
-import persistence.sql.dml.builder.SelectQueryBuilder;
 import persistence.sql.dml.builder.UpdateQueryBuilder;
 import persistence.sql.meta.pk.PKField;
 
 import java.lang.reflect.Field;
-import java.util.List;
 
 public class EntityPersist {
     private final JdbcTemplate jdbcTemplate;
-    private final SelectQueryBuilder selectQueryBuilder;
     private final InsertQueryBuilder insertQueryBuilder;
     private final UpdateQueryBuilder updateQueryBuilder;
     private final DeleteQueryBuilder deleteQueryBuilder;
 
     public EntityPersist(final JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
-        this.selectQueryBuilder = new SelectQueryBuilder();
         this.insertQueryBuilder = new InsertQueryBuilder();
         this.updateQueryBuilder = new UpdateQueryBuilder();
         this.deleteQueryBuilder = new DeleteQueryBuilder();
-    }
-
-    public <T> T findOneOrFail(Class<T> clazz, Long id) {
-        return jdbcTemplate.queryForObject(selectQueryBuilder.findById(clazz, id), new RowMapperImpl<>(clazz));
     }
 
     public <T> void insert(T entity) {
@@ -39,17 +30,11 @@ public class EntityPersist {
         jdbcTemplate.execute(sql);
     }
 
-    public <T> T findOne(T entity, Long id) {
-        List<T> entities = (List<T>) jdbcTemplate.query(
-                selectQueryBuilder.findById(entity.getClass(), id),
-                new RowMapperImpl<>(entity.getClass())
-        );
-        if (entities.isEmpty()) {
-            return null;
-        }
-        return entities.get(0);
+    public <T> void delete(T entity) {
+        jdbcTemplate.execute(deleteQueryBuilder.generateSQL(entity));
     }
 
+    // TODO 해당 코드 리팩토링 필요
     public <T> Long getPKValue(T entity) {
         Field pkField = new PKField(entity.getClass()).getField();
         pkField.setAccessible(true);
@@ -62,7 +47,4 @@ public class EntityPersist {
         return value;
     }
 
-    public <T> void delete(T entity) {
-        jdbcTemplate.execute(deleteQueryBuilder.generateSQL(entity));
-    }
 }

--- a/src/main/java/persistence/entity/EntityPersist.java
+++ b/src/main/java/persistence/entity/EntityPersist.java
@@ -4,9 +4,6 @@ import jdbc.JdbcTemplate;
 import persistence.sql.dml.builder.DeleteQueryBuilder;
 import persistence.sql.dml.builder.InsertQueryBuilder;
 import persistence.sql.dml.builder.UpdateQueryBuilder;
-import persistence.sql.meta.pk.PKField;
-
-import java.lang.reflect.Field;
 
 public class EntityPersist {
     private final JdbcTemplate jdbcTemplate;
@@ -33,18 +30,4 @@ public class EntityPersist {
     public <T> void delete(T entity) {
         jdbcTemplate.execute(deleteQueryBuilder.generateSQL(entity));
     }
-
-    // TODO 해당 코드 리팩토링 필요
-    public <T> Long getPKValue(T entity) {
-        Field pkField = new PKField(entity.getClass()).getField();
-        pkField.setAccessible(true);
-        Long value;
-        try {
-            value = (Long) pkField.get(entity);
-        } catch (IllegalAccessException e) {
-            throw new IllegalArgumentException(e);
-        }
-        return value;
-    }
-
 }

--- a/src/test/java/persistence/entity/EntityManagerImplTest.java
+++ b/src/test/java/persistence/entity/EntityManagerImplTest.java
@@ -54,13 +54,20 @@ class EntityManagerImplTest {
 
     @DisplayName("find/id로 조회/성공")
     @Test
-    void find() {
+    void findOne() {
         Person person = new Person("hoon25", 20, "hoon25@gmail.com");
         entityManager.persist(person);
 
         Person findPerson = entityManager.find(Person.class, 1L);
 
         assertThat(person.getName()).isEqualTo(findPerson.getName());
+    }
+
+    @DisplayName("find/id로 조회/실패")
+    @Test
+    void findOneFail() {
+        assertThatThrownBy(() -> entityManager.find(Person.class, 1L))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @DisplayName("persist/entity 저장/저장 성공")


### PR DESCRIPTION
`RowMapperImpl`는 기존에도 동적으로 생성되게 구현되어있었습니다. 하지만 미션에서 명시된 **ResultSet의 metadata를 잘 활용해보자**의 방식은 아닌 것 같아서, 변경해야할 부분이 필요하면 리뷰해주시면 감사하겠습니다!

[1단계 PR 리뷰 관련](https://github.com/next-step/jpa-entity-manager/pull/120#discussion_r1508981620)
![image](https://github.com/next-step/jpa-entity-manager/assets/69202388/e1941490-9b82-4311-9228-abeea44b322c)

코드는 `EntityManager`로 이동했습니다. 
(이곳에 있는 것도 어색하긴 한데 미션 진행하면서 또 옮겨질것 같아서, 우선 `EntityManager`에 두었습니다!)

