### PR TITLE
2단계 - 엔터티 초기화 (EntityLoader)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@
 ### step1
 
 - [x] 엔터티의 데이터베이스 매핑, 쿼리 생성 및 실행의 책임을 EntityManger에서 EntityPersister로 옮겨주기
+
+### step2
+
+- [ ] EntityPersister의 find에 대한 책임을 EntityLoader로 옮겨주기

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@
 
 ### step2
 
-- [ ] EntityPersister의 find에 대한 책임을 EntityLoader로 옮겨주기
+- [x] EntityPersister의 find에 대한 책임을 EntityLoader로 옮겨주기

--- a/src/main/java/persistence/entity/EntityLoader.java
+++ b/src/main/java/persistence/entity/EntityLoader.java
@@ -2,7 +2,10 @@ package persistence.entity;
 
 import database.Database;
 import persistence.sql.dml.DMLQueryBuilder;
+import persistence.sql.model.PKColumn;
 import persistence.sql.model.Table;
+
+import java.util.List;
 
 public class EntityLoader {
 
@@ -19,5 +22,27 @@ public class EntityLoader {
         DMLQueryBuilder queryBuilder = new DMLQueryBuilder(table);
         String findByIdQuery = queryBuilder.buildFindByIdQuery(id);
         return database.executeQueryForObject(clazz, findByIdQuery);
+    }
+
+    public boolean isExist(Object entity) {
+        Class<?> clazz = entity.getClass();
+        Table table = entityMetaCache.getTable(clazz);
+        DMLQueryBuilder queryBuilder = new DMLQueryBuilder(table);
+
+        Object id = getEntityId(entity);
+        String findByIdQuery = queryBuilder.buildFindByIdQuery(id);
+
+        List<?> results = database.executeQuery(clazz, findByIdQuery);
+        return !results.isEmpty();
+    }
+
+    private Object getEntityId(Object entity) {
+        Class<?> clazz = entity.getClass();
+        Table table = entityMetaCache.getTable(clazz);
+
+        EntityBinder entityBinder = new EntityBinder(entity);
+
+        PKColumn pkColumn = table.getPKColumn();
+        return entityBinder.getValue(pkColumn);
     }
 }

--- a/src/main/java/persistence/entity/EntityLoader.java
+++ b/src/main/java/persistence/entity/EntityLoader.java
@@ -1,0 +1,23 @@
+package persistence.entity;
+
+import database.Database;
+import persistence.sql.dml.DMLQueryBuilder;
+import persistence.sql.model.Table;
+
+public class EntityLoader {
+
+    private final Database database;
+    private final EntityMetaCache entityMetaCache;
+
+    public EntityLoader(Database database, EntityMetaCache entityMetaCache) {
+        this.database = database;
+        this.entityMetaCache = entityMetaCache;
+    }
+
+    public <T> T read(Class<T> clazz, Object id) {
+        Table table = entityMetaCache.getTable(clazz);
+        DMLQueryBuilder queryBuilder = new DMLQueryBuilder(table);
+        String findByIdQuery = queryBuilder.buildFindByIdQuery(id);
+        return database.executeQueryForObject(clazz, findByIdQuery);
+    }
+}

--- a/src/main/java/persistence/entity/EntityMetaCache.java
+++ b/src/main/java/persistence/entity/EntityMetaCache.java
@@ -1,0 +1,27 @@
+package persistence.entity;
+
+import persistence.sql.model.Table;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public class EntityMetaCache {
+
+    private final ConcurrentHashMap<Class<?>, Table> tables;
+
+    public EntityMetaCache() {
+        this.tables = new ConcurrentHashMap<>();
+    }
+
+    public Table getTable(Class<?> clazz) {
+        Table findTable = tables.get(clazz);
+
+        if (findTable != null) {
+            return findTable;
+        }
+
+        Table table = new Table(clazz);
+        tables.put(clazz, table);
+
+        return table;
+    }
+}

--- a/src/main/java/persistence/entity/EntityPersister.java
+++ b/src/main/java/persistence/entity/EntityPersister.java
@@ -6,36 +6,36 @@ import persistence.sql.model.PKColumn;
 import persistence.sql.model.Table;
 
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class EntityPersister {
 
     private final Database database;
-    private final ConcurrentHashMap<Class<?>, Table> tables;
-    private final ConcurrentHashMap<Class<?>, DMLQueryBuilder> queryBuilders;
+    private final EntityMetaCache entityMetaCache;
 
-    public EntityPersister(Database database) {
+    public EntityPersister(Database database, EntityMetaCache entityMetaCache) {
         this.database = database;
-        this.tables = new ConcurrentHashMap<>();
-        this.queryBuilders = new ConcurrentHashMap<>();
+        this.entityMetaCache = entityMetaCache;
     }
 
     public void create(Object entity) {
         Class<?> clazz = entity.getClass();
-        DMLQueryBuilder dmlQueryBuilder = getQueryBuilder(clazz);
-        String insertQuery = dmlQueryBuilder.buildInsertQuery(entity);
+        Table table = entityMetaCache.getTable(clazz);
+        DMLQueryBuilder queryBuilder = new DMLQueryBuilder(table);
+        String insertQuery = queryBuilder.buildInsertQuery(entity);
         database.execute(insertQuery);
     }
 
     public <T> T read(Class<T> clazz, Object id) {
-        DMLQueryBuilder queryBuilder = getQueryBuilder(clazz);
+        Table table = entityMetaCache.getTable(clazz);
+        DMLQueryBuilder queryBuilder = new DMLQueryBuilder(table);
         String findByIdQuery = queryBuilder.buildFindByIdQuery(id);
         return database.executeQueryForObject(clazz, findByIdQuery);
     }
 
     public boolean isExist(Object entity) {
         Class<?> clazz = entity.getClass();
-        DMLQueryBuilder queryBuilder = getQueryBuilder(clazz);
+        Table table = entityMetaCache.getTable(clazz);
+        DMLQueryBuilder queryBuilder = new DMLQueryBuilder(table);
 
         Object id = getEntityId(entity);
         String findByIdQuery = queryBuilder.buildFindByIdQuery(id);
@@ -46,7 +46,8 @@ public class EntityPersister {
 
     public void update(Object entity) {
         Class<?> clazz = entity.getClass();
-        DMLQueryBuilder queryBuilder = getQueryBuilder(clazz);
+        Table table = entityMetaCache.getTable(clazz);
+        DMLQueryBuilder queryBuilder = new DMLQueryBuilder(table);
 
         Object id = getEntityId(entity);
         String updateByIdQuery = queryBuilder.buildUpdateByIdQuery(entity, id);
@@ -56,7 +57,8 @@ public class EntityPersister {
 
     public void delete(Object entity) {
         Class<?> clazz = entity.getClass();
-        DMLQueryBuilder queryBuilder = getQueryBuilder(clazz);
+        Table table = entityMetaCache.getTable(clazz);
+        DMLQueryBuilder queryBuilder = new DMLQueryBuilder(table);
 
         Object id = getEntityId(entity);
         String deleteByIdQuery = queryBuilder.buildDeleteByIdQuery(id);
@@ -66,38 +68,11 @@ public class EntityPersister {
 
     private Object getEntityId(Object entity) {
         Class<?> clazz = entity.getClass();
-        Table table = getTable(clazz);
+        Table table = entityMetaCache.getTable(clazz);
 
         EntityBinder entityBinder = new EntityBinder(entity);
 
         PKColumn pkColumn = table.getPKColumn();
         return entityBinder.getValue(pkColumn);
-    }
-
-    private Table getTable(Class<?> clazz) {
-        Table findTable = tables.get(clazz);
-
-        if (findTable != null) {
-            return findTable;
-        }
-
-        Table table = new Table(clazz);
-        tables.put(clazz, table);
-
-        return table;
-    }
-
-    private DMLQueryBuilder getQueryBuilder(Class<?> clazz) {
-        DMLQueryBuilder findQueryBuilder = queryBuilders.get(clazz);
-
-        if (findQueryBuilder != null) {
-            return findQueryBuilder;
-        }
-
-        Table table = getTable(clazz);
-        DMLQueryBuilder queryBuilder = new DMLQueryBuilder(table);
-        queryBuilders.put(clazz, queryBuilder);
-
-        return queryBuilder;
     }
 }

--- a/src/main/java/persistence/entity/EntityPersister.java
+++ b/src/main/java/persistence/entity/EntityPersister.java
@@ -32,18 +32,6 @@ public class EntityPersister {
         return database.executeQueryForObject(clazz, findByIdQuery);
     }
 
-    public boolean isExist(Object entity) {
-        Class<?> clazz = entity.getClass();
-        Table table = entityMetaCache.getTable(clazz);
-        DMLQueryBuilder queryBuilder = new DMLQueryBuilder(table);
-
-        Object id = getEntityId(entity);
-        String findByIdQuery = queryBuilder.buildFindByIdQuery(id);
-
-        List<?> results = database.executeQuery(clazz, findByIdQuery);
-        return !results.isEmpty();
-    }
-
     public void update(Object entity) {
         Class<?> clazz = entity.getClass();
         Table table = entityMetaCache.getTable(clazz);

--- a/src/main/java/persistence/entity/EntityPersister.java
+++ b/src/main/java/persistence/entity/EntityPersister.java
@@ -25,13 +25,6 @@ public class EntityPersister {
         database.execute(insertQuery);
     }
 
-    public <T> T read(Class<T> clazz, Object id) {
-        Table table = entityMetaCache.getTable(clazz);
-        DMLQueryBuilder queryBuilder = new DMLQueryBuilder(table);
-        String findByIdQuery = queryBuilder.buildFindByIdQuery(id);
-        return database.executeQueryForObject(clazz, findByIdQuery);
-    }
-
     public void update(Object entity) {
         Class<?> clazz = entity.getClass();
         Table table = entityMetaCache.getTable(clazz);

--- a/src/main/java/persistence/entity/SimpleEntityManger.java
+++ b/src/main/java/persistence/entity/SimpleEntityManger.java
@@ -3,14 +3,16 @@ package persistence.entity;
 public class SimpleEntityManger implements EntityManager {
 
     private final EntityPersister persister;
+    private final EntityLoader loader;
 
-    public SimpleEntityManger(EntityPersister persister) {
+    public SimpleEntityManger(EntityPersister persister, EntityLoader loader) {
         this.persister = persister;
+        this.loader = loader;
     }
 
     @Override
     public <T> T find(Class<T> clazz, Object id) {
-        return persister.read(clazz, id);
+        return loader.read(clazz, id);
     }
 
     @Override

--- a/src/main/java/persistence/entity/SimpleEntityManger.java
+++ b/src/main/java/persistence/entity/SimpleEntityManger.java
@@ -17,7 +17,7 @@ public class SimpleEntityManger implements EntityManager {
 
     @Override
     public void persist(Object entity) {
-        if (persister.isExist(entity)) {
+        if (loader.isExist(entity)) {
             persister.update(entity);
         }
         persister.create(entity);

--- a/src/test/java/persistence/entity/EntityLoaderTest.java
+++ b/src/test/java/persistence/entity/EntityLoaderTest.java
@@ -1,11 +1,11 @@
 package persistence.entity;
 
-import database.*;
+import database.Database;
+import database.DatabaseServer;
+import database.H2;
+import database.SimpleDatabase;
 import jdbc.JdbcTemplate;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import persistence.sql.ddl.DDLQueryBuilder;
 import persistence.sql.dialect.Dialect;
 import persistence.sql.dialect.H2Dialect;
@@ -18,9 +18,8 @@ import java.sql.SQLException;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class EntityPersisterTest {
+public class EntityLoaderTest {
 
     private static DatabaseServer server;
     private static JdbcTemplate jdbcTemplate;
@@ -79,52 +78,11 @@ class EntityPersisterTest {
     }
 
     @Test
-    @DisplayName("person을 이용하여 create 메서드 테스트")
-    void create() {
-        Person3 person3 = new Person3("qwer", 12, "qwe@ema.com");
+    @DisplayName("person을 이용하여 read 메서드 테스트")
+    void read() {
+        Person3 result = persister.read(Person3.class, 3L);
 
-        persister.create(person3);
-        Person3 result = jdbcTemplate.queryForObject("SELECT * FROM users WHERE id=4L", new EntityRowMapper<>(Person3.class));
-
-        Person3 expect = new Person3(4L, "qwer", 12, "qwe@ema.com");
+        Person3 expect = new Person3(3L, "qwer3", 3, "email3@email.com");
         assertThat(result).isEqualTo(expect);
-    }
-
-    @ParameterizedTest
-    @MethodSource
-    @DisplayName("person을 이용하여 isExist 메서드 테스트")
-    void isExist(Person3 person, boolean expect) {
-        boolean result = persister.isExist(person);
-
-        assertThat(result).isEqualTo(expect);
-    }
-
-    private static Stream<Arguments> isExist() {
-        return Stream.of(
-          Arguments.arguments(new Person3(1L, "qwer3", 3, "email3@email.com"), true),
-          Arguments.arguments(new Person3(5L, "qwer3", 3, "email3@email.com"), false)
-        );
-    }
-
-    @Test
-    void update() {
-        Person3 person = new Person3(2L, "qwer", 12, "qwe@ema.com");
-
-        persister.update(person);
-        Person3 result = jdbcTemplate.queryForObject("SELECT * FROM users WHERE id=2L", new EntityRowMapper<>(Person3.class));
-
-        Person3 expect = new Person3(2L, "qwer", 12, "qwe@ema.com");
-        assertThat(result).isEqualTo(expect);
-    }
-
-    @Test
-    void deleteById() {
-        Person3 person = new Person3(2L, "aa", 123, "qeqwewq");
-
-        persister.delete(person);
-
-        assertThatThrownBy(() -> jdbcTemplate.queryForObject("SELECT * FROM users WHERE id=2L", new EntityRowMapper<>(Person3.class)))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("Expected 1 result, got 0");
     }
 }

--- a/src/test/java/persistence/entity/EntityLoaderTest.java
+++ b/src/test/java/persistence/entity/EntityLoaderTest.java
@@ -6,6 +6,9 @@ import database.H2;
 import database.SimpleDatabase;
 import jdbc.JdbcTemplate;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import persistence.sql.ddl.DDLQueryBuilder;
 import persistence.sql.dialect.Dialect;
 import persistence.sql.dialect.H2Dialect;
@@ -23,7 +26,7 @@ public class EntityLoaderTest {
 
     private static DatabaseServer server;
     private static JdbcTemplate jdbcTemplate;
-    private static EntityPersister persister;
+    private static EntityLoader loader;
 
     private static DDLQueryBuilder ddlQueryBuilder;
     private static DMLQueryBuilder dmlQueryBuilder;
@@ -38,7 +41,7 @@ public class EntityLoaderTest {
 
         Database database = new SimpleDatabase(jdbcTemplate);
         EntityMetaCache entityMetaCache = new EntityMetaCache();
-        persister = new EntityPersister(database, entityMetaCache);
+        loader = new EntityLoader(database, entityMetaCache);
 
         Dialect dialect = new H2Dialect();
         Table table = new Table(Person3.class);
@@ -80,9 +83,25 @@ public class EntityLoaderTest {
     @Test
     @DisplayName("person을 이용하여 read 메서드 테스트")
     void read() {
-        Person3 result = persister.read(Person3.class, 3L);
+        Person3 result = loader.read(Person3.class, 3L);
 
         Person3 expect = new Person3(3L, "qwer3", 3, "email3@email.com");
         assertThat(result).isEqualTo(expect);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    @DisplayName("person을 이용하여 isExist 메서드 테스트")
+    void isExist(Person3 person, boolean expect) {
+        boolean result = loader.isExist(person);
+
+        assertThat(result).isEqualTo(expect);
+    }
+
+    private static Stream<Arguments> isExist() {
+        return Stream.of(
+                Arguments.arguments(new Person3(1L, "qwer3", 3, "email3@email.com"), true),
+                Arguments.arguments(new Person3(5L, "qwer3", 3, "email3@email.com"), false)
+        );
     }
 }

--- a/src/test/java/persistence/entity/EntityPersisterTest.java
+++ b/src/test/java/persistence/entity/EntityPersisterTest.java
@@ -90,22 +90,6 @@ class EntityPersisterTest {
         assertThat(result).isEqualTo(expect);
     }
 
-    @ParameterizedTest
-    @MethodSource
-    @DisplayName("person을 이용하여 isExist 메서드 테스트")
-    void isExist(Person3 person, boolean expect) {
-        boolean result = persister.isExist(person);
-
-        assertThat(result).isEqualTo(expect);
-    }
-
-    private static Stream<Arguments> isExist() {
-        return Stream.of(
-          Arguments.arguments(new Person3(1L, "qwer3", 3, "email3@email.com"), true),
-          Arguments.arguments(new Person3(5L, "qwer3", 3, "email3@email.com"), false)
-        );
-    }
-
     @Test
     void update() {
         Person3 person = new Person3(2L, "qwer", 12, "qwe@ema.com");

--- a/src/test/java/persistence/entity/SimpleEntityMangerTest.java
+++ b/src/test/java/persistence/entity/SimpleEntityMangerTest.java
@@ -42,10 +42,12 @@ class SimpleEntityMangerTest {
 
         Connection jdbcConnection = server.getConnection();
         jdbcTemplate = new JdbcTemplate(jdbcConnection);
-
         Database database = new SimpleDatabase(jdbcTemplate);
-        EntityPersister persister = new EntityPersister(database);;
-        entityManager = new SimpleEntityManger(persister);
+
+        EntityMetaCache entityMetaCache = new EntityMetaCache();
+        EntityPersister persister = new EntityPersister(database, entityMetaCache);
+        EntityLoader loader = new EntityLoader(database, entityMetaCache);
+        entityManager = new SimpleEntityManger(persister, loader);
 
         Dialect dialect = new H2Dialect();
         Table table = new Table(Person3.class);


### PR DESCRIPTION
정완님께서 이전 리뷰에서 말씀해주신 것 처럼
단순히 `read`에 대한 책임을 `EntityLoader`로 옮기면 되기 때문에 빠르게 리뷰요청 드립니다!

그런데, `EntityPersister`의 `isExist` 메서드도 내부적으로 `read`와 관련된 책임이 있다고 생각되어 `EntityLoader`로 함께 옮겼습니다.
헌데 이 것이 올바르게 책임의 분배가 이루어진 것인지 명확하게 느껴지지 않네요 😅
(entity에서 id를 추출하는 로직이 함께 이동되기 때문인 것 같습니다)

이와 관련해 정완님의 의견도 리뷰와 함께 알려주시면 감사하겠습니다!