### PR TITLE
[Entity 구현 - Step 1단계] 엔터티 매핑 (EntityPersister)

### DIFF
--- a/src/main/java/docs/step1.md
+++ b/src/main/java/docs/step1.md
@@ -1,0 +1,7 @@
+# 1단계 - 엔터티 매핑 (EntityPersister)
+
+## 요구사항 1 - 엔터티의 데이터베이스 매핑, 쿼리 생성 및 실행
+
+## 요구사항 2 - EntityManager 의 책임 줄여주기
+
+- [X] EntityManager 의 구현체에서 쿼리 생성 및 데이터 매핑 에 대한 책임을 EntityPersister 로 옮겨주자

--- a/src/main/java/domain/constants/CommonConstants.java
+++ b/src/main/java/domain/constants/CommonConstants.java
@@ -6,4 +6,6 @@ public class CommonConstants {
     }
 
     public static final String COMMA = ", ";
+    public static final String EQUAL = " = ";
+    public static final String AND = " and ";
 }

--- a/src/main/java/domain/vo/ColumnAndValue.java
+++ b/src/main/java/domain/vo/ColumnAndValue.java
@@ -1,0 +1,26 @@
+package domain.vo;
+
+import java.util.Objects;
+
+public class ColumnAndValue {
+
+    private final ColumnName columnName;
+    private final ColumnValue columnValue;
+
+    public ColumnAndValue(ColumnName columnName, ColumnValue columnValue) {
+        this.columnName = columnName;
+        this.columnValue = columnValue;
+    }
+
+    public ColumnName getColumnName() {
+        return columnName;
+    }
+
+    public ColumnValue getColumnValue() {
+        return columnValue;
+    }
+
+    public boolean isNotBlankOrEmpty() {
+        return Objects.nonNull(columnName) && Objects.nonNull(columnValue);
+    }
+}

--- a/src/main/java/domain/vo/ColumnName.java
+++ b/src/main/java/domain/vo/ColumnName.java
@@ -3,7 +3,7 @@ package domain.vo;
 import jakarta.persistence.Column;
 
 import java.lang.reflect.Field;
-import java.util.LinkedList;
+import java.util.List;
 
 import static domain.utils.StringUtils.isBlankOrEmpty;
 
@@ -14,7 +14,7 @@ public class ColumnName {
     /**
      * 그 필드명에 있어야 name 이 생성된다.
      */
-    public ColumnName(LinkedList<Field> fields, Field field) {
+    public ColumnName(List<Field> fields, Field field) {
         if (!fields.contains(field)) {
             throw new IllegalArgumentException("존재하는 fieldName 이 아닙니다.");
         }

--- a/src/main/java/jdbc/JdbcTemplate.java
+++ b/src/main/java/jdbc/JdbcTemplate.java
@@ -22,18 +22,27 @@ public class JdbcTemplate {
         }
     }
 
+    public int executeUpdate(final String sql) {
+        try (final Statement statement = connection.createStatement()) {
+            return statement.executeUpdate(sql);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
     /**
      * getLastIndex 수행 메소드
      */
-    public Long executeAndReturnKey(final String sql) {
+    public Object executeAndReturnKey(final String sql) {
         ResultSet resultSet = null;
 
         try (final Statement statement = connection.createStatement()) {
             statement.execute(sql, Statement.RETURN_GENERATED_KEYS);
             resultSet = statement.getGeneratedKeys();
-            Long seq = null;
+            Object seq = null;
             if (resultSet.next()) {
-                seq = resultSet.getLong("id");
+                seq = resultSet.getObject("id");
             }
             return seq;
         } catch (Exception e) {

--- a/src/main/java/persistence/entity/EntityManager.java
+++ b/src/main/java/persistence/entity/EntityManager.java
@@ -1,10 +1,17 @@
 package persistence.entity;
 
+/**
+ * + * EntityManager 는 데이터베이스와의 세션을 관리하고, 엔티티의 영속성 컨텍스트(Persistence Context)를 관리합니다.
+ * + * 영속성 컨텍스트는 엔티티 객체의 변경을 추적하고, 데이터베이스와의 동기화를 담당합니다.
+ * +
+ */
 public interface EntityManager {
 
     <T> T find(Class<T> clazz, Long id);
 
-    Object persist(Object entity);
+    Object persist(Object object);
 
-    void remove(Object entity);
+    boolean update(Object object);
+
+    void remove(Object object);
 }

--- a/src/main/java/persistence/entity/EntityPersister.java
+++ b/src/main/java/persistence/entity/EntityPersister.java
@@ -1,0 +1,14 @@
+package persistence.entity;
+
+/**
+ * EntityPersister 는 엔터티의 메타데이터와 데이터베이스 매핑 정보를 제공하고,
+ * 변경된 엔터티를 데이터베이스에 동기화하는 역할
+ */
+public interface EntityPersister {
+
+    Object insert(Object object);
+
+    boolean update(Object object);
+
+    void delete(Object object);
+}

--- a/src/main/java/persistence/entity/EntityPersisterImpl.java
+++ b/src/main/java/persistence/entity/EntityPersisterImpl.java
@@ -1,0 +1,48 @@
+package persistence.entity;
+
+import domain.EntityMetaData;
+import domain.dialect.Dialect;
+import domain.vo.JavaMappingType;
+import jdbc.JdbcTemplate;
+import persistence.sql.dml.DeleteQueryBuilder;
+import persistence.sql.dml.UpdateQueryBuilder;
+
+public class EntityPersisterImpl implements EntityPersister {
+
+    /**
+     * 엔티티 클래스와 데이터베이스 테이블 간의 매핑 정보를 관리하고, 엔티티의 상태 변화를 데이터베이스에 반영하는 구체적인 작업을 수행
+     * 예를 들어, EntityManager 를 통해 persist 메서드가 호출되면,
+     * -> 내부적으로 Hibernate 는 해당 엔티티의 EntityPersister  를 사용하여 SQL INSERT 문을 생성하고 실행
+     */
+
+    private final JdbcTemplate jdbcTemplate;
+    private final JavaMappingType javaMappingType;
+    private final Dialect dialect;
+    private final EntityMetaData entityMetaData;
+
+    public EntityPersisterImpl(JdbcTemplate jdbcTemplate, JavaMappingType javaMappingType,
+                               Dialect dialect, EntityMetaData entityMetaData) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.javaMappingType = javaMappingType;
+        this.dialect = dialect;
+        this.entityMetaData = entityMetaData;
+    }
+
+    @Override
+    public Object insert(Object object) {
+        UpdateQueryBuilder queryBuilder = new UpdateQueryBuilder(javaMappingType, dialect, entityMetaData);
+        return jdbcTemplate.executeAndReturnKey(queryBuilder.insertQuery(object));
+    }
+
+    @Override
+    public boolean update(Object object) {
+        UpdateQueryBuilder queryBuilder = new UpdateQueryBuilder(javaMappingType, dialect, entityMetaData);
+        return jdbcTemplate.executeUpdate(queryBuilder.updateQuery(object)) > 0;
+    }
+
+    @Override
+    public void delete(Object object) {
+        DeleteQueryBuilder queryBuilder = new DeleteQueryBuilder(javaMappingType, entityMetaData);
+        jdbcTemplate.execute(queryBuilder.deleteByIdQuery(object));
+    }
+}

--- a/src/main/java/persistence/entity/SimpleEntityManager.java
+++ b/src/main/java/persistence/entity/SimpleEntityManager.java
@@ -1,35 +1,38 @@
 package persistence.entity;
 
+import domain.EntityMetaData;
 import jdbc.JdbcTemplate;
 import jdbc.RowMapperImpl;
-import persistence.sql.ddl.DdlQueryBuilder;
-import persistence.sql.dml.DmlQueryBuilder;
+import persistence.sql.dml.SelectQueryBuilder;
 
 public class SimpleEntityManager implements EntityManager {
 
+    private final EntityPersister entityPersister;
     private final JdbcTemplate jdbcTemplate;
-    private final DdlQueryBuilder ddlQueryBuilder;
-    private final DmlQueryBuilder dmlQueryBuilder;
 
-    public SimpleEntityManager(JdbcTemplate jdbcTemplate, DdlQueryBuilder ddlQueryBuilder,
-                               DmlQueryBuilder dmlQueryBuilder) {
+    public SimpleEntityManager(EntityPersister entityPersister, JdbcTemplate jdbcTemplate) {
+        this.entityPersister = entityPersister;
         this.jdbcTemplate = jdbcTemplate;
-        this.ddlQueryBuilder = ddlQueryBuilder;
-        this.dmlQueryBuilder = dmlQueryBuilder;
     }
 
     @Override
     public <T> T find(Class<T> clazz, Long id) {
-        return jdbcTemplate.queryForObject(dmlQueryBuilder.findByIdQuery(clazz, id), new RowMapperImpl<>(clazz));
+        SelectQueryBuilder selectQueryBuilder = new SelectQueryBuilder(new EntityMetaData(clazz));
+        return jdbcTemplate.queryForObject(selectQueryBuilder.findByIdQuery(id), new RowMapperImpl<>(clazz));
+
+    }
+
+    public Object persist(Object object) {
+        return entityPersister.insert(object);
     }
 
     @Override
-    public Object persist(Object entity) {
-        return jdbcTemplate.executeAndReturnKey(dmlQueryBuilder.insertQuery(entity));
+    public boolean update(Object object) {
+        return entityPersister.update(object);
     }
 
     @Override
-    public void remove(Object entity) {
-        jdbcTemplate.execute(dmlQueryBuilder.deleteByIdQuery(entity));
+    public void remove(Object object) {
+        entityPersister.delete(object);
     }
 }

--- a/src/main/java/persistence/sql/ddl/DropQueryBuilder.java
+++ b/src/main/java/persistence/sql/ddl/DropQueryBuilder.java
@@ -1,0 +1,18 @@
+package persistence.sql.ddl;
+
+import domain.EntityMetaData;
+
+public class DropQueryBuilder {
+
+    private static final String DROP_TABLE_QUERY = "DROP TABLE %s IF EXISTS;";
+
+    private final EntityMetaData entityMetaData;
+
+    public DropQueryBuilder(EntityMetaData entityMetaData) {
+        this.entityMetaData = entityMetaData;
+    }
+
+    public String dropTable() {
+        return String.format(DROP_TABLE_QUERY, entityMetaData.getTableName());
+    }
+}

--- a/src/main/java/persistence/sql/dml/DeleteQueryBuilder.java
+++ b/src/main/java/persistence/sql/dml/DeleteQueryBuilder.java
@@ -1,0 +1,53 @@
+package persistence.sql.dml;
+
+import domain.EntityMetaData;
+import domain.vo.ColumnName;
+import domain.vo.ColumnValue;
+import domain.vo.JavaMappingType;
+import jakarta.persistence.Id;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.stream.Collectors;
+
+public class DeleteQueryBuilder {
+
+    private static final String DELETE_QUERY = "DELETE %s WHERE %s = %s;";
+
+    private final JavaMappingType javaMappingType;
+    private final EntityMetaData entityMetaData;
+
+    public DeleteQueryBuilder(JavaMappingType javaMappingType, EntityMetaData entityMetaData) {
+        this.javaMappingType = javaMappingType;
+        this.entityMetaData = entityMetaData;
+    }
+
+    public String deleteQuery(Object object, Field field, Object value) {
+        LinkedList<Field> fields = Arrays.stream(object.getClass().getDeclaredFields())
+                .collect(Collectors.toCollection(LinkedList::new));
+
+        ColumnName columnName = new ColumnName(fields, field);
+        ColumnValue columnValue = new ColumnValue(javaMappingType, javaMappingType.getJavaTypeByClass(object.getClass()), value);
+
+        return String.format(DELETE_QUERY, entityMetaData.getTableName(), columnName.getName(), columnValue.getValue());
+    }
+
+    public String deleteByIdQuery(Object object) {
+        Field idField = Arrays.stream(object.getClass().getDeclaredFields())
+                .collect(Collectors.toCollection(LinkedList::new)).stream()
+                .filter(field -> field.isAnnotationPresent(Id.class))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("primary key 값이 없습니다."));
+
+        Object idFieldValue;
+        try {
+            idField.setAccessible(true);
+            idFieldValue = idField.get(object);
+        } catch (IllegalAccessException | IllegalArgumentException e) {
+            throw new IllegalArgumentException("Field 정보가 존재하지 않습니다.");
+        }
+
+        return deleteQuery(object, idField, idFieldValue);
+    }
+}

--- a/src/main/java/persistence/sql/dml/SelectQueryBuilder.java
+++ b/src/main/java/persistence/sql/dml/SelectQueryBuilder.java
@@ -1,0 +1,23 @@
+package persistence.sql.dml;
+
+import domain.EntityMetaData;
+
+public class SelectQueryBuilder {
+
+    private static final String FIND_ALL_QUERY = "SELECT * FROM %s;";
+    private static final String FIND_BY_ID_QUERY = "SELECT * FROM %s WHERE %s = %s;";
+
+    private final EntityMetaData entityMetaData;
+
+    public SelectQueryBuilder(EntityMetaData entityMetaData) {
+        this.entityMetaData = entityMetaData;
+    }
+
+    public String findAllQuery() {
+        return String.format(FIND_ALL_QUERY, entityMetaData.getTableName());
+    }
+
+    public String findByIdQuery(Object condition) {
+        return String.format(FIND_BY_ID_QUERY, entityMetaData.getTableName(), entityMetaData.getIdField(), condition);
+    }
+}

--- a/src/test/java/persistence/entity/EntityPersisterImplTest.java
+++ b/src/test/java/persistence/entity/EntityPersisterImplTest.java
@@ -1,0 +1,110 @@
+package persistence.entity;
+
+import database.DatabaseServer;
+import database.H2;
+import domain.EntityMetaData;
+import domain.Person3;
+import domain.dialect.Dialect;
+import domain.dialect.H2Dialect;
+import domain.vo.JavaMappingType;
+import jdbc.JdbcTemplate;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import persistence.sql.ddl.CreateQueryBuilder;
+import persistence.sql.ddl.DropQueryBuilder;
+import persistence.sql.dml.UpdateQueryBuilder;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class EntityPersisterImplTest {
+
+    static JavaMappingType javaMappingType = new JavaMappingType();
+    static Dialect dialect = new H2Dialect();
+    static EntityMetaData entityMetaData = new EntityMetaData(Person3.class);
+
+    static DatabaseServer server;
+    static JdbcTemplate jdbcTemplate;
+    static EntityPersister entityPersister;
+    static SimpleEntityManager simpleEntityManager;
+
+    Person3 person;
+
+    @BeforeAll
+    static void init() throws SQLException {
+        server = new H2();
+        server.start();
+        jdbcTemplate = new JdbcTemplate(server.getConnection());
+        entityPersister = new EntityPersisterImpl(jdbcTemplate, javaMappingType, dialect, entityMetaData);
+        simpleEntityManager = new SimpleEntityManager(new EntityPersisterImpl(jdbcTemplate, javaMappingType, dialect, entityMetaData), jdbcTemplate);
+    }
+
+    @BeforeEach
+    void setUp() {
+        person = new Person3(1L, "test", 20, "test@test.com");
+        createTable();
+    }
+
+    @AfterEach
+    void remove() {
+        dropTable();
+    }
+
+    @AfterAll
+    static void destroy() {
+        server.stop();
+    }
+
+    @DisplayName("insert 테스트")
+    @Test
+    void insertTest() {
+        entityPersister.insert(person);
+        Person3 person3 = simpleEntityManager.find(person.getClass(), person.getId());
+        assertAll(
+                () -> assertThat(person3.getId()).isEqualTo(person.getId()),
+                () -> assertThat(person3.getName()).isEqualTo(person.getName()),
+                () -> assertThat(person3.getAge()).isEqualTo(person.getAge()),
+                () -> assertThat(person3.getEmail()).isEqualTo(person.getEmail())
+        );
+
+    }
+
+    @DisplayName("insert 후 update 테스트")
+    @Test
+    void updateTest() {
+        insertData();
+        boolean result = entityPersister.update(new Person3(person.getId(), "test", 35, "test@test.com"));
+        assertThat(result).isTrue();
+    }
+
+    @DisplayName("delete 후 조회하려고 할 때 exception 테스트")
+    @Test
+    void deleteTest() {
+        insertData();
+        entityPersister.delete(person);
+        assertThrows(RuntimeException.class, () -> simpleEntityManager.find(person.getClass(), person.getId()));
+    }
+
+    private void createTable() {
+        CreateQueryBuilder createQueryBuilder = new CreateQueryBuilder(dialect, entityMetaData);
+        jdbcTemplate.execute(createQueryBuilder.createTable(person));
+    }
+
+    private void insertData() {
+        UpdateQueryBuilder updateQueryBuilder = new UpdateQueryBuilder(javaMappingType, dialect, entityMetaData);
+        jdbcTemplate.execute(updateQueryBuilder.insertQuery(person));
+    }
+
+    private void dropTable() {
+        DropQueryBuilder dropQueryBuilder = new DropQueryBuilder(entityMetaData);
+        jdbcTemplate.execute(dropQueryBuilder.dropTable());
+    }
+
+}


### PR DESCRIPTION
## 내용
- 이전 단계에서 구현했던 `DdlQueryBuilder`, `DmlQueryBuilder` 의 역할을 분리하여 각각의 클래스로 나누는 리팩토링을 진행했습니다. 
- 그 중에서 `UpdateQueryBuilder` 에 대해서는 고민이 많았는데요, whereClause 나 column/value clause 를 만드는 과정을 좀 더 추상화하거나 역할을 분리하는 것이 좋을 것 같은데 한번 성주님 피드백을 요청드리는 것이 좋을듯하여 pr 요청드립니다!
- `EntityManager` 에는 **EntityPersister, JdbcTemplete(현재는 Loader 가 아직 구현되지 않았으므로)** 만 주입 받도록 수정해보았습니다.

확인 부탁드립니다🙇‍♀️