### PR TITLE
2단계 - 엔터티 초기화 (EntityLoader)

### DIFF
--- a/src/main/java/persistence/entity/EntityLoader.java
+++ b/src/main/java/persistence/entity/EntityLoader.java
@@ -1,0 +1,31 @@
+package persistence.entity;
+
+import jdbc.JdbcTemplate;
+import jdbc.RowMapperImpl;
+import persistence.sql.dml.builder.SelectQueryBuilder;
+import persistence.sql.dml.model.DMLColumn;
+import persistence.sql.model.Table;
+
+public class EntityLoader {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public EntityLoader(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public <T> T find(Class<T> clazz, Long id) {
+        final String query = findQuery(clazz, id);
+
+        return jdbcTemplate.queryForObject(query, new RowMapperImpl<>(clazz));
+    }
+
+    private <T> String findQuery(Class<T> clazz, Long id) {
+        final SelectQueryBuilder queryBuilder = new SelectQueryBuilder(
+                new Table(clazz), new DMLColumn(clazz)
+        );
+
+        return queryBuilder.findById(id).build();
+    }
+
+}

--- a/src/main/java/persistence/entity/EntityManagerImpl.java
+++ b/src/main/java/persistence/entity/EntityManagerImpl.java
@@ -1,35 +1,20 @@
 package persistence.entity;
 
-import jdbc.JdbcTemplate;
-import jdbc.RowMapperImpl;
 import persistence.EntityPersister;
-import persistence.sql.dml.builder.SelectQueryBuilder;
-import persistence.sql.dml.model.DMLColumn;
-import persistence.sql.model.Table;
 
 public class EntityManagerImpl implements EntityManager {
 
+    private final EntityLoader entityLoader;
     private final EntityPersister entityPersister;
-    private final JdbcTemplate jdbcTemplate;
 
-    public EntityManagerImpl(EntityPersister entityPersister, JdbcTemplate jdbcTemplate) {
+    public EntityManagerImpl(EntityLoader entityLoader, EntityPersister entityPersister) {
+        this.entityLoader = entityLoader;
         this.entityPersister = entityPersister;
-        this.jdbcTemplate = jdbcTemplate;
     }
 
     @Override
     public <T> T find(Class<T> clazz, Long id) {
-        final String query = findQuery(clazz, id);
-
-        return jdbcTemplate.queryForObject(query, new RowMapperImpl<>(clazz));
-    }
-
-    private <T> String findQuery(Class<T> clazz, Long id) {
-        final SelectQueryBuilder queryBuilder = new SelectQueryBuilder(
-                new Table(clazz), new DMLColumn(clazz)
-        );
-
-        return queryBuilder.findById(id).build();
+        return entityLoader.find(clazz, id);
     }
 
     @Override

--- a/src/test/java/persistence/EntityPersisterTest.java
+++ b/src/test/java/persistence/EntityPersisterTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import persistence.entity.EntityLoader;
 import persistence.entity.EntityManager;
 import persistence.entity.EntityManagerImpl;
 import persistence.sql.ddl.converter.H2TypeConverter;
@@ -25,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class EntityPersisterTest {
 
+    private EntityLoader entityLoader;
     private EntityPersister entityPersister;
     private EntityManager entityManager;
     private DatabaseServer server;
@@ -43,8 +45,9 @@ class EntityPersisterTest {
                 new Table(expected.getClass()),
                 new DDLColumn(new H2TypeConverter(), new H2PrimaryKeyGenerationType())
         );
+        entityLoader = new EntityLoader(jdbcTemplate);
         entityPersister = new EntityPersister(jdbcTemplate);
-        entityManager = new EntityManagerImpl(entityPersister, jdbcTemplate);
+        entityManager = new EntityManagerImpl(entityLoader, entityPersister);
 
         final String createQuery = queryBuilder.create(Person.class);
         jdbcTemplate.execute(createQuery);

--- a/src/test/java/persistence/entity/EntityManagerImplTest.java
+++ b/src/test/java/persistence/entity/EntityManagerImplTest.java
@@ -26,8 +26,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class EntityManagerImplTest {
 
     private DatabaseServer server;
-    private EntityManager entityManager;
+    private EntityLoader entityLoader;
     private EntityPersister entityPersister;
+    private EntityManager entityManager;
     private JdbcTemplate jdbcTemplate;
     private QueryBuilder queryBuilder;
     private Person expected;
@@ -39,8 +40,9 @@ class EntityManagerImplTest {
         expected = DummyPerson.of();
 
         jdbcTemplate = new JdbcTemplate(server.getConnection());
+        entityLoader = new EntityLoader(jdbcTemplate);
         entityPersister = new EntityPersister(jdbcTemplate);
-        entityManager = new EntityManagerImpl(entityPersister, jdbcTemplate);
+        entityManager = new EntityManagerImpl(entityLoader, entityPersister);
         queryBuilder = new DDLQueryBuilder(
                 new Table(expected.getClass()),
                 new DDLColumn(new H2TypeConverter(), new H2PrimaryKeyGenerationType())


### PR DESCRIPTION
안녕하세요, 태화님.

2단계 엔티티 초기화 구현입니다.
EntityManager 구현체에서, find() 메서드에 존재하는 역할을 EntityLoader로 옮기면서 EntityManagerImpl 에서는 JdbcTemplate에 의존하지 않고, EntityLoader 및 EntityPersister를 통해서만 Object를 관리하게 되도록 변경하였는데,
요구사항을 제대로 이해한건지 잘 모르겠네욥..

혹 잘못 이해한게 있으면 말씀 부탁드리겠습니다.

아 그리고 지난번 남겨주신 커멘트에서 댓글 달았었는데, 시간되실때 확인 한 번 부탁드려요 🙇  [PR](https://github.com/next-step/jpa-entity-manager/pull/158/files#r1518879186)